### PR TITLE
Adds a flow graph component and implement world settings using this component for re-usability

### DIFF
--- a/Config/BaseFlow.ini
+++ b/Config/BaseFlow.ini
@@ -1,3 +1,4 @@
 [CoreRedirects]
 +ClassRedirects=(OldName="/Script/Flow.FlowNode_CustomEvent",NewName="/Script/Flow.FlowNode_CustomInput")
 +PropertyRedirects=(OldName="FlowAsset.CustomEvents",NewName="CustomInputs")
++PropertyRedirects=(OldName="FlowWorldSettings.FlowAsset",NewName="FlowGraph.FlowAsset")

--- a/Config/DefaultFlow.ini
+++ b/Config/DefaultFlow.ini
@@ -1,3 +1,4 @@
 [CoreRedirects]
 +ClassRedirects=(OldName="/Script/Flow.FlowNode_CustomEvent",NewName="/Script/Flow.FlowNode_CustomInput")
 +PropertyRedirects=(OldName="FlowAsset.CustomEvents",NewName="CustomInputs")
++PropertyRedirects=(OldName="FlowWorldSettings.FlowAsset",NewName="FlowGraph.FlowAsset")

--- a/Source/Flow/Private/FlowGraphComponent.cpp
+++ b/Source/Flow/Private/FlowGraphComponent.cpp
@@ -1,0 +1,32 @@
+﻿#include "FlowGraphComponent.h"
+#include "FlowAsset.h"
+#include "FlowSubsystem.h"
+
+#include "Engine/GameInstance.h"
+#include "GameFramework/Actor.h"
+
+void UFlowGraphComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (IsValid(FlowAsset) && (!bAuthorityOnly || GetOwner()->HasAuthority()))
+	{
+		if (UFlowSubsystem* FlowSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UFlowSubsystem>())
+		{
+			FlowSubsystem->StartRootFlow(GetOwner(), FlowAsset);
+		}
+	}
+}
+
+void UFlowGraphComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	if (IsValid(FlowAsset) && (!bAuthorityOnly || GetOwner()->HasAuthority()))
+	{
+		if (UFlowSubsystem* FlowSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UFlowSubsystem>())
+		{
+			FlowSubsystem->FinishRootFlow(GetOwner(), FlowAsset);
+		}
+	}
+
+	Super::EndPlay(EndPlayReason);
+}

--- a/Source/Flow/Private/FlowWorldSettings.cpp
+++ b/Source/Flow/Private/FlowWorldSettings.cpp
@@ -1,34 +1,8 @@
 #include "FlowWorldSettings.h"
-#include "FlowSubsystem.h"
+#include "FlowGraphComponent.h"
 
 AFlowWorldSettings::AFlowWorldSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
-	, FlowAsset(nullptr)
+	, FlowGraph(CreateDefaultSubobject<UFlowGraphComponent>(TEXT("FlowGraph")))
 {
-}
-
-void AFlowWorldSettings::BeginPlay()
-{
-	Super::BeginPlay();
-
-	if (FlowAsset && HasAuthority())
-	{
-		if (UFlowSubsystem* FlowSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UFlowSubsystem>())
-		{
-			FlowSubsystem->StartRootFlow(GetWorld(), FlowAsset);
-		}
-	}
-}
-
-void AFlowWorldSettings::EndPlay(const EEndPlayReason::Type EndPlayReason)
-{
-	if (FlowAsset && HasAuthority())
-	{
-		if (UFlowSubsystem* FlowSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UFlowSubsystem>())
-		{
-			FlowSubsystem->FinishRootFlow(GetWorld(), FlowAsset);
-		}
-	}
-
-	Super::EndPlay(EndPlayReason);
 }

--- a/Source/Flow/Public/FlowGraphComponent.h
+++ b/Source/Flow/Public/FlowGraphComponent.h
@@ -1,0 +1,22 @@
+﻿#pragma once
+
+#include "Components/ActorComponent.h"
+#include "FlowGraphComponent.generated.h"
+
+class UFlowAsset;
+
+UCLASS(Blueprintable, meta = (BlueprintSpawnableComponent))
+class FLOW_API UFlowGraphComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, Category = "Flow")
+	UFlowAsset* FlowAsset;
+
+	UPROPERTY(EditAnywhere, Category = "Flow")
+	bool bAuthorityOnly = true;
+
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+};

--- a/Source/Flow/Public/FlowWorldSettings.h
+++ b/Source/Flow/Public/FlowWorldSettings.h
@@ -3,6 +3,8 @@
 #include "GameFramework/WorldSettings.h"
 #include "FlowWorldSettings.generated.h"
 
+class UFlowGraphComponent;
+
 /**
  * World Settings used to start a Flow for this world
  */
@@ -11,9 +13,7 @@ class FLOW_API AFlowWorldSettings : public AWorldSettings
 {
 	GENERATED_UCLASS_BODY()
 
+public:	
 	UPROPERTY(EditAnywhere, Category = "Flow")
-	class UFlowAsset* FlowAsset;
-
-	virtual void BeginPlay() override;
-	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+	UFlowGraphComponent* FlowGraph;
 };

--- a/Source/FlowEditor/Private/LevelEditor/SLevelEditorFlow.cpp
+++ b/Source/FlowEditor/Private/LevelEditor/SLevelEditorFlow.cpp
@@ -1,5 +1,6 @@
 #include "LevelEditor/SLevelEditorFlow.h"
 #include "FlowAsset.h"
+#include "FlowGraphComponent.h"
 #include "FlowWorldSettings.h"
 
 #include "Editor.h"
@@ -26,7 +27,7 @@ void SLevelEditorFlow::CreateFlowWidget()
 	{
 		if (const AFlowWorldSettings* WorldSettings = Cast<AFlowWorldSettings>(World->GetWorldSettings()))
 		{
-			FlowPath = WorldSettings->FlowAsset ? FName(*WorldSettings->FlowAsset->GetPathName()) : FName();
+			FlowPath = WorldSettings->FlowGraph->FlowAsset ? FName(*WorldSettings->FlowGraph->FlowAsset->GetPathName()) : FName();
 		}
 	}
 
@@ -78,14 +79,15 @@ void SLevelEditorFlow::OnFlowChanged(const FAssetData& NewAsset)
 		{
 			if (UObject* NewObject = NewAsset.GetAsset())
 			{
-				WorldSettings->FlowAsset = Cast<UFlowAsset>(NewObject);
+				WorldSettings->FlowGraph->FlowAsset = Cast<UFlowAsset>(NewObject);
 			}
 			else
 			{
-				WorldSettings->FlowAsset = nullptr;
+				WorldSettings->FlowGraph->FlowAsset = nullptr;
 			}
 
-			WorldSettings->MarkPackageDirty();
+			bool bSucceeded = WorldSettings->MarkPackageDirty();
+			ensure(bSucceeded);
 		}
 	}
 }


### PR DESCRIPTION
I was thinking about it, and I think it might be better to have a component that owns a flow asset and registers it automatically to the subsystem. This way, we can re-use the logic within the world settings anywhere a flow asset is needed. What do you think?