### PR TITLE
fix UFlowAsset::ClearInstances

### DIFF
--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -182,7 +182,7 @@ void UFlowAsset::ClearInstances()
 
 	for (int32 i = ActiveInstances.Num() - 1; i >= 0; i--)
 	{
-		if (ActiveInstances[i])
+		if (ActiveInstances.IsValidIndex(i))
 		{
 			ActiveInstances[i]->FinishFlow(false);
 		}


### PR DESCRIPTION
If you load a savegame and exit the game afterwards you can get an exception because activeInstances is empty. I've sticked to your style and added a check like in FlowSubSystem::Deinitialize