### PR TITLE
Allow hierarchical identity searches

### DIFF
--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -7,6 +7,7 @@
 #include "FlowSettings.h"
 #include "Nodes/Route/FlowNode_SubGraph.h"
 
+#include "Algo/Transform.h"
 #include "Engine/GameInstance.h"
 #include "Engine/World.h"
 #include "Misc/FileHelper.h"
@@ -483,6 +484,16 @@ void UFlowSubsystem::FindComponents(const FGameplayTagContainer& Tags, TSet<TWea
 TArray<TWeakObjectPtr<UFlowComponent>> UFlowSubsystem::FindComponents(const FGameplayTag& Tag) const
 {
 	TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
-	FlowComponentRegistry.MultiFind(Tag, ComponentsPerTag);
+
+	Algo::TransformIf(FlowComponentRegistry, ComponentsPerTag,
+		[&Tag](auto& TagComponentPair)
+	{
+		return TagComponentPair.Key.MatchesTag(Tag);
+	},
+		[](auto& TagComponentPair)
+	{
+		return TagComponentPair.Value;
+	});
+
 	return ComponentsPerTag;
 }

--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -354,8 +354,7 @@ void UFlowSubsystem::OnIdentityTagsRemoved(UFlowComponent* Component, const FGam
 
 TSet<UFlowComponent*> UFlowSubsystem::GetFlowComponentsByTag(const FGameplayTag Tag, const TSubclassOf<UFlowComponent> ComponentClass) const
 {
-	TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents;
-	FlowComponentRegistry.MultiFind(Tag, FoundComponents);
+	TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents = FindComponents(Tag);
 
 	TSet<UFlowComponent*> Result;
 	for (const TWeakObjectPtr<UFlowComponent>& Component : FoundComponents)
@@ -388,8 +387,7 @@ TSet<UFlowComponent*> UFlowSubsystem::GetFlowComponentsByTags(const FGameplayTag
 
 TSet<AActor*> UFlowSubsystem::GetFlowActorsByTag(const FGameplayTag Tag, const TSubclassOf<AActor> ActorClass) const
 {
-	TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents;
-	FlowComponentRegistry.MultiFind(Tag, FoundComponents);
+	TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents = FindComponents(Tag);
 
 	TSet<AActor*> Result;
 	for (const TWeakObjectPtr<UFlowComponent>& Component : FoundComponents)
@@ -422,8 +420,7 @@ TSet<AActor*> UFlowSubsystem::GetFlowActorsByTags(const FGameplayTagContainer Ta
 
 TMap<AActor*, UFlowComponent*> UFlowSubsystem::GetFlowActorsAndComponentsByTag(const FGameplayTag Tag, const TSubclassOf<AActor> ActorClass) const
 {
-	TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents;
-	FlowComponentRegistry.MultiFind(Tag, FoundComponents);
+	TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents = FindComponents(Tag);
 
 	TMap<AActor*, UFlowComponent*> Result;
 	for (const TWeakObjectPtr<UFlowComponent>& Component : FoundComponents)
@@ -460,8 +457,7 @@ void UFlowSubsystem::FindComponents(const FGameplayTagContainer& Tags, TSet<TWea
 	{
 		for (const FGameplayTag& Tag : Tags)
 		{
-			TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
-			FlowComponentRegistry.MultiFind(Tag, ComponentsPerTag);
+			TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag = FindComponents(Tag);
 			OutComponents.Append(ComponentsPerTag);
 		}
 	}
@@ -470,8 +466,7 @@ void UFlowSubsystem::FindComponents(const FGameplayTagContainer& Tags, TSet<TWea
 		TSet<TWeakObjectPtr<UFlowComponent>> ComponentsWithAnyTag;
 		for (const FGameplayTag& Tag : Tags)
 		{
-			TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
-			FlowComponentRegistry.MultiFind(Tag, ComponentsPerTag);
+			TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag = FindComponents(Tag);
 			ComponentsWithAnyTag.Append(ComponentsPerTag);
 		}
 
@@ -483,4 +478,11 @@ void UFlowSubsystem::FindComponents(const FGameplayTagContainer& Tags, TSet<TWea
 			}
 		}
 	}
+}
+
+TArray<TWeakObjectPtr<UFlowComponent>> UFlowSubsystem::FindComponents(const FGameplayTag& Tag) const
+{
+	TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
+	FlowComponentRegistry.MultiFind(Tag, ComponentsPerTag);
+	return ComponentsPerTag;
 }

--- a/Source/Flow/Public/FlowSubsystem.h
+++ b/Source/Flow/Public/FlowSubsystem.h
@@ -174,8 +174,7 @@ public:
 	{
 		static_assert(TPointerIsConvertibleFromTo<T, const UActorComponent>::Value, "'T' template parameter to GetComponents must be derived from UActorComponent");
 
-		TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents;
-		FlowComponentRegistry.MultiFind(Tag, FoundComponents);
+		TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents = FindComponents(Tag);
 
 		TSet<TWeakObjectPtr<T>> Result;
 		for (const TWeakObjectPtr<UFlowComponent>& Component : FoundComponents)
@@ -216,8 +215,7 @@ public:
 	{
 		static_assert(TPointerIsConvertibleFromTo<T, const AActor>::Value, "'T' template parameter to GetComponents must be derived from AActor");
 
-		TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents;
-		FlowComponentRegistry.MultiFind(Tag, FoundComponents);
+		TArray<TWeakObjectPtr<UFlowComponent>> FoundComponents = FindComponents(Tag);
 
 		TMap<TWeakObjectPtr<T>, TWeakObjectPtr<UFlowComponent>> Result;
 		for (const TWeakObjectPtr<UFlowComponent>& Component : FoundComponents)
@@ -254,4 +252,6 @@ public:
 
 private:
 	void FindComponents(const FGameplayTagContainer& Tags, TSet<TWeakObjectPtr<UFlowComponent>>& OutComponents, const EGameplayContainerMatchType MatchType) const;
+
+	TArray<TWeakObjectPtr<UFlowComponent>> FindComponents(const FGameplayTag& Tag) const;
 };


### PR DESCRIPTION
When searching for flow components with the requested identity, use MatchesTag on each registered flow component instead of MultiFind on the entire container to allow for hierarchical identity searches (e.g. a flow component with identity Identity.General.Specific can be found by searching for Identity.General)