### PR TITLE
set custom color for even "native" nodes

### DIFF
--- a/Source/Flow/Public/FlowSettings.h
+++ b/Source/Flow/Public/FlowSettings.h
@@ -24,4 +24,8 @@ class UFlowSettings final : public UDeveloperSettings
 	// How many nodes of given class should be preloaded with the Flow Asset instance?
 	UPROPERTY(Config, EditAnywhere, Category = "Preload")
 	TMap<TSubclassOf<UFlowNode>, int32> DefaultPreloadDepth;
+	
+	// Add custom color to a Node.
+	UPROPERTY(Config, EditAnywhere, Category = "Design", meta=(DisplayName="Color per Node"))
+	TMap<TSubclassOf<UFlowNode>, FColor> NodeColors;
 };

--- a/Source/Flow/Public/Nodes/FlowNode.h
+++ b/Source/Flow/Public/Nodes/FlowNode.h
@@ -69,7 +69,17 @@ public:
 	virtual FText GetNodeToolTip() const;
 	
 	// This method allows to have different for every node instance, i.e. Red if node represents enemy, Green if node represents a friend
-	virtual bool GetNodeTitleColor(FLinearColor& OutColor) const { return false; }
+	virtual bool GetNodeTitleColor(FLinearColor& OutColor) const
+	{
+		const FColor* Color = UFlowSettings::Get()->NodeColors.Find(GetClass());
+
+		if (!Color)
+			return false;
+
+		OutColor = *Color;
+
+		return true;
+	}
 
 	EFlowNodeStyle GetNodeStyle() const { return NodeStyle; }
 


### PR DESCRIPTION
Since designers have their own idea of how the colors of different actions should look, we would like to enable them to set different colors for native nodes (nodes supplied by the plugin)