### PR TITLE
Move harvest nodes within editor preprocessor

### DIFF
--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -99,7 +99,6 @@ void UFlowAsset::UnregisterNode(const FGuid& NodeGuid)
 	HarvestNodeConnections();
 	MarkPackageDirty();
 }
-#endif
 
 void UFlowAsset::HarvestNodeConnections()
 {
@@ -132,17 +131,13 @@ void UFlowAsset::HarvestNodeConnections()
 			}
 		}
 
-#if WITH_EDITOR
 		Node->SetFlags(RF_Transactional);
 		Node->Modify();
-#endif
 		Node->SetConnections(Connections);
-
-#if WITH_EDITOR
 		Node->PostEditChange();
-#endif
 	}
 }
+#endif
 
 UFlowNode* UFlowAsset::GetNode(const FGuid& Guid) const
 {

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -107,10 +107,10 @@ public:
 
 	void RegisterNode(const FGuid& NewGuid, UFlowNode* NewNode);
 	void UnregisterNode(const FGuid& NodeGuid);
-#endif
-
+	
 	// Processes all nodes and creates map of all pin connections
-	void HarvestNodeConnections();
+    void HarvestNodeConnections();
+#endif
 
 	UFlowNode* GetNode(const FGuid& Guid) const;
 	TMap<FGuid, UFlowNode*> GetNodes() const { return Nodes; }

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -109,7 +109,7 @@ public:
 	void UnregisterNode(const FGuid& NodeGuid);
 	
 	// Processes all nodes and creates map of all pin connections
-    void HarvestNodeConnections();
+    	void HarvestNodeConnections();
 #endif
 
 	UFlowNode* GetNode(const FGuid& Guid) const;


### PR DESCRIPTION
`HarvestNodeConnections` is called in Editor only so it makes sense to keep them in preprocessor.