### PR TITLE
Fix user can delete Start node.

### DIFF
--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -32,6 +32,7 @@ UFlowNode::UFlowNode(const FObjectInitializer& ObjectInitializer)
 #if WITH_EDITOR
 	Category = TEXT("Uncategorized");
 	NodeStyle = EFlowNodeStyle::Default;
+	bCanDelete = bCanDuplicate = true;
 #endif
 
 	InputPins = {DefaultInputPin};

--- a/Source/Flow/Private/Nodes/Route/FlowNode_Start.cpp
+++ b/Source/Flow/Private/Nodes/Route/FlowNode_Start.cpp
@@ -6,6 +6,7 @@ UFlowNode_Start::UFlowNode_Start(const FObjectInitializer& ObjectInitializer)
 #if WITH_EDITOR
 	Category = TEXT("Route");
 	NodeStyle = EFlowNodeStyle::InOut;
+	bCanDelete = bCanDuplicate = false;
 #endif
 
 	InputPins = {};

--- a/Source/Flow/Public/Nodes/FlowNode.h
+++ b/Source/Flow/Public/Nodes/FlowNode.h
@@ -44,6 +44,9 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category = "FlowNode")
 	EFlowNodeStyle NodeStyle;
 
+	uint8 bCanDelete : 1;
+	uint8 bCanDuplicate : 1;
+
 public:
 	FFlowNodeEvent OnReconstructionRequested;
 #endif

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -553,6 +553,16 @@ void UFlowGraphNode::GetNodeContextMenuActions(class UToolMenu* Menu, class UGra
 	}
 }
 
+bool UFlowGraphNode::CanUserDeleteNode() const
+{
+	return FlowNode ? FlowNode->bCanDelete : Super::CanUserDeleteNode();
+}
+
+bool UFlowGraphNode::CanDuplicateNode() const
+{
+	return FlowNode ? FlowNode->bCanDuplicate : Super::CanDuplicateNode();
+}
+
 TSharedPtr<SGraphNode> UFlowGraphNode::CreateVisualWidget()
 {
 	return SNew(SFlowGraphNode, this);

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -125,7 +125,8 @@ public:
 
 	// UEdGraphNode
 	virtual void GetNodeContextMenuActions(class UToolMenu* Menu, class UGraphNodeContextMenuContext* Context) const override;
-
+	virtual bool CanUserDeleteNode() const override;
+	virtual bool CanDuplicateNode() const override;
 	virtual TSharedPtr<SGraphNode> CreateVisualWidget() override;
 	virtual FText GetNodeTitle(ENodeTitleType::Type TitleType) const override;
 	virtual FLinearColor GetNodeTitleColor() const override;

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode_Start.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode_Start.h
@@ -10,7 +10,5 @@ class FLOWEDITOR_API UFlowGraphNode_Start : public UFlowGraphNode
 
 	// UEdGraphNode
 	virtual TSharedPtr<SGraphNode> CreateVisualWidget() override;
-	virtual bool CanUserDeleteNode() const override { return false; }
-	virtual bool CanDuplicateNode() const override { return false; }
 	// --
 };


### PR DESCRIPTION
This PR fixes deleting of `Start` node. It is also possible to set this setting per `Flow Node` instead of `Flow Graph Node` eliminating the need of creating additional `Flow Graph Node` classes if you don't want the node to be deleted or duplicated.