### PR TITLE
Fix node not being registered with the asset after undoing it's deletion

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
@@ -650,6 +650,7 @@ void FFlowAssetEditor::DeleteSelectedNodes()
 {
 	const FScopedTransaction Transaction(LOCTEXT("DeleteSelectedNode", "Delete Selected Node"));
 	FocusedGraphEditor->GetCurrentGraph()->Modify();
+	FlowAsset->Modify();
 
 	const FGraphPanelSelectionSet SelectedNodes = FocusedGraphEditor->GetSelectedNodes();
 	SetUISelectionState(NAME_None);


### PR DESCRIPTION
Problem:
If you delete a node from the graph, the node is unregistered from it's `UFlowAsset`. So, if you undo a deleted node, it won't work anymore, since it's missing from `UFlowAsset::Nodes`.

Proposed solution:
Marking current state of `UFlowAsset` to be stored inside undo/redo buffer (just as it's already done for the graph). This way, if we undo the deleted nodes, `UFlowAsset` state will be restored with appropriate guid.