### PR TITLE
Clear previously selected nodes before new node creation

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
@@ -633,6 +633,7 @@ void FFlowAssetEditor::OnSelectedNodesChanged(const TSet<UObject*>& Nodes)
 
 void FFlowAssetEditor::SelectSingleNode(UEdGraphNode* Node) const
 {
+	FocusedGraphEditor->ClearSelectionSet();
 	FocusedGraphEditor->SetNodeSelection(Node, true);
 }
 


### PR DESCRIPTION
I find it quite annoying when I create new node and previous selected nodes stay selected, I have to unselect all nodes and select new node again to align it properly.