### PR TITLE
Make UFlowNodeBlueprint not final to allow for subclassing

### DIFF
--- a/Source/Flow/Public/Nodes/FlowNodeBlueprint.h
+++ b/Source/Flow/Public/Nodes/FlowNodeBlueprint.h
@@ -9,7 +9,7 @@
  */
 
 UCLASS(BlueprintType)
-class FLOW_API UFlowNodeBlueprint final : public UBlueprint
+class FLOW_API UFlowNodeBlueprint : public UBlueprint
 {
 	GENERATED_UCLASS_BODY()
 


### PR DESCRIPTION
Pretty straightforward change, which should make it so that you can create other types of UFlowNode blueprint assets in the game's editor module without having to edit Flow's source code.
![image](https://user-images.githubusercontent.com/10626859/151261308-8be22cdd-33cf-4f08-8550-7e0981f5a082.png)
