### PR TITLE
fix localization collision caused by identical keys

### DIFF
--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -412,7 +412,7 @@ void SFlowGraphNode::CreateInputSideAddButton(TSharedPtr<SVerticalBox> OutputBox
 	{
 		const TSharedRef<SWidget> AddPinButton = AddPinButtonContent(
 			LOCTEXT("FlowNodeAddPinButton", "Add pin"),
-			LOCTEXT("FlowNodeAddPinButton_Tooltip", "Adds an input pin")
+			LOCTEXT("FlowNodeAddPinButton_InputTooltip", "Adds an input pin")
 		);
 
 		FMargin AddPinPadding = Settings->GetInputPinPadding();
@@ -434,7 +434,7 @@ void SFlowGraphNode::CreateOutputSideAddButton(TSharedPtr<SVerticalBox> OutputBo
 	{
 		const TSharedRef<SWidget> AddPinButton = AddPinButtonContent(
 			LOCTEXT("FlowNodeAddPinButton", "Add pin"),
-			LOCTEXT("FlowNodeAddPinButton_Tooltip", "Adds an output pin")
+			LOCTEXT("FlowNodeAddPinButton_OutputTooltip", "Adds an output pin")
 		);
 
 		FMargin AddPinPadding = Settings->GetOutputPinPadding();


### PR DESCRIPTION
Found this by trying to open the localization dashboard in a project with flow enabled. 