### PR TITLE
Fix add output pin + icon

### DIFF
--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -475,7 +475,7 @@ void SFlowGraphNode::CreateOutputSideAddButton(TSharedPtr<SVerticalBox> OutputBo
 		.Padding(7,0,0,0)
 		[
 			SNew(SImage)
-			.Image(FEditorStyle::GetBrush(TEXT("PropertyWindow.Button_AddToArray")))
+			.Image(FEditorStyle::GetBrush(TEXT("Icons.PlusCircle")))
 		];
 
 		AddPinButton(OutputBox, AddPinWidget.ToSharedRef(), EGPD_Output);


### PR DESCRIPTION
Changes the FeditorStyle brush to the one used in the add input pin for the + icon