### PR TITLE
Rename uses of FEditorStyle to FAppStyle as it's been deprecated in 5.1 …

### DIFF
--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "FlowSave.h"
 #include "FlowTypes.h"
+#include "Templates/SubclassOf.h"
 #include "FlowAsset.generated.h"
 
 class UFlowNode;

--- a/Source/Flow/Public/Nodes/FlowNode.h
+++ b/Source/Flow/Public/Nodes/FlowNode.h
@@ -7,6 +7,7 @@
 #include "Engine/StreamableManager.h"
 #include "GameplayTagContainer.h"
 #include "VisualLogger/VisualLoggerDebugSnapshotInterface.h"
+#include "Templates/SubclassOf.h"
 
 #include "FlowTypes.h"
 #include "Nodes/FlowPin.h"

--- a/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
@@ -111,17 +111,17 @@ void FFlowAssetEditor::RegisterTabSpawners(const TSharedRef<class FTabManager>& 
 	InTabManager->RegisterTabSpawner(GraphTab, FOnSpawnTab::CreateSP(this, &FFlowAssetEditor::SpawnTab_GraphCanvas))
 				.SetDisplayName(LOCTEXT("GraphTab", "Viewport"))
 				.SetGroup(WorkspaceMenuCategoryRef)
-				.SetIcon(FSlateIcon(FEditorStyle::GetStyleSetName(), "GraphEditor.EventGraph_16x"));
+				.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "GraphEditor.EventGraph_16x"));
 
 	InTabManager->RegisterTabSpawner(DetailsTab, FOnSpawnTab::CreateSP(this, &FFlowAssetEditor::SpawnTab_Details))
 				.SetDisplayName(LOCTEXT("DetailsTab", "Details"))
 				.SetGroup(WorkspaceMenuCategoryRef)
-				.SetIcon(FSlateIcon(FEditorStyle::GetStyleSetName(), "LevelEditor.Tabs.Details"));
+				.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "LevelEditor.Tabs.Details"));
 
 	InTabManager->RegisterTabSpawner(PaletteTab, FOnSpawnTab::CreateSP(this, &FFlowAssetEditor::SpawnTab_Palette))
 				.SetDisplayName(LOCTEXT("PaletteTab", "Palette"))
 				.SetGroup(WorkspaceMenuCategoryRef)
-				.SetIcon(FSlateIcon(FEditorStyle::GetStyleSetName(), "Kismet.Tabs.Palette"));
+				.SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "Kismet.Tabs.Palette"));
 }
 
 void FFlowAssetEditor::UnregisterTabSpawners(const TSharedRef<class FTabManager>& InTabManager)

--- a/Source/FlowEditor/Private/Asset/FlowAssetToolbar.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetToolbar.cpp
@@ -118,10 +118,10 @@ void SFlowAssetBreadcrumb::Construct(const FArguments& InArgs, const TWeakObject
 	SAssignNew(BreadcrumbTrail, SBreadcrumbTrail<FFlowBreadcrumb>)
 		.OnCrumbClicked(this, &SFlowAssetBreadcrumb::OnCrumbClicked)
 		.Visibility_Static(&FFlowAssetEditor::GetDebuggerVisibility)
-		.ButtonStyle(FEditorStyle::Get(), "FlatButton")
-		.DelimiterImage(FEditorStyle::GetBrush("Sequencer.BreadcrumbIcon"))
+		.ButtonStyle(FAppStyle::Get(), "FlatButton")
+		.DelimiterImage(FAppStyle::GetBrush("Sequencer.BreadcrumbIcon"))
 		.PersistentBreadcrumbs(true)
-		.TextStyle(FEditorStyle::Get(), "Sequencer.BreadcrumbText");
+		.TextStyle(FAppStyle::Get(), "Sequencer.BreadcrumbText");
 
 	ChildSlot
 	[

--- a/Source/FlowEditor/Private/FlowEditorCommands.cpp
+++ b/Source/FlowEditor/Private/FlowEditorCommands.cpp
@@ -25,7 +25,7 @@ void FFlowToolbarCommands::RegisterCommands()
 }
 
 FFlowGraphCommands::FFlowGraphCommands()
-	: TCommands<FFlowGraphCommands>("FlowGraph", LOCTEXT("FlowGraph", "Flow Graph"), NAME_None, FEditorStyle::GetStyleSetName())
+	: TCommands<FFlowGraphCommands>("FlowGraph", LOCTEXT("FlowGraph", "Flow Graph"), NAME_None, FAppStyle::GetAppStyleSetName())
 {
 }
 
@@ -50,7 +50,7 @@ void FFlowGraphCommands::RegisterCommands()
 }
 
 FFlowSpawnNodeCommands::FFlowSpawnNodeCommands()
-	: TCommands<FFlowSpawnNodeCommands>(TEXT("FFlowSpawnNodeCommands"), LOCTEXT("FlowGraph_SpawnNodes", "Flow Graph - Spawn Nodes"), NAME_None, FEditorStyle::GetStyleSetName())
+	: TCommands<FFlowSpawnNodeCommands>(TEXT("FFlowSpawnNodeCommands"), LOCTEXT("FlowGraph_SpawnNodes", "Flow Graph - Spawn Nodes"), NAME_None, FAppStyle::GetAppStyleSetName())
 {
 }
 
@@ -116,7 +116,7 @@ void FFlowSpawnNodeCommands::RegisterCommands()
 		const FText CommandLabelText = FText::FromString(NodeClass->GetName());
 		const FText Description = FText::Format(LOCTEXT("NodeSpawnDescription", "Hold down the bound keys and left click in the graph panel to spawn a {0} node."), CommandLabelText);
 
-		FUICommandInfo::MakeCommandInfo(this->AsShared(), CommandInfo, FName(*NodeSpawns[x]), CommandLabelText, Description, FSlateIcon(FEditorStyle::GetStyleSetName(), *FString::Printf(TEXT("%s.%s"), *this->GetContextName().ToString(), *NodeSpawns[x])), EUserInterfaceActionType::Button, Chord);
+		FUICommandInfo::MakeCommandInfo(this->AsShared(), CommandInfo, FName(*NodeSpawns[x]), CommandLabelText, Description, FSlateIcon(FAppStyle::GetAppStyleSetName(), *FString::Printf(TEXT("%s.%s"), *this->GetContextName().ToString(), *NodeSpawns[x])), EUserInterfaceActionType::Button, Chord);
 
 		NodeCommands.Add(NodeClass, CommandInfo);
 	}

--- a/Source/FlowEditor/Private/FlowEditorCommands.cpp
+++ b/Source/FlowEditor/Private/FlowEditorCommands.cpp
@@ -68,7 +68,7 @@ void FFlowSpawnNodeCommands::RegisterCommands()
 		FString ClassName;
 		if (FParse::Value(*NodeSpawns[x], TEXT("Class="), ClassName))
 		{
-			UClass* FoundClass = FindObject<UClass>(ANY_PACKAGE, *ClassName, true);
+			UClass* FoundClass = FindObject<UClass>(nullptr, *ClassName, true);
 			if (FoundClass && FoundClass->IsChildOf(UFlowNode::StaticClass()))
 			{
 				NodeClass = FoundClass;

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -392,8 +392,8 @@ void UFlowGraphSchema::GatherFlowNodes()
 	const FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(AssetRegistryConstants::ModuleName);
 
 	FARFilter Filter;
-	Filter.ClassNames.Add(UBlueprint::StaticClass()->GetFName());
-	Filter.ClassNames.Add(UBlueprintGeneratedClass::StaticClass()->GetFName());
+	Filter.ClassPaths.Add(UBlueprint::StaticClass()->GetClassPathName());
+	Filter.ClassPaths.Add(UBlueprintGeneratedClass::StaticClass()->GetClassPathName());
 	Filter.bRecursiveClasses = true;
 
 	TArray<FAssetData> FoundAssets;
@@ -426,9 +426,9 @@ void UFlowGraphSchema::AddAsset(const FAssetData& AssetData, const bool bBatch)
 			return;
 		}
 
-		TArray<FName> AncestorClassNames;
-		AssetRegistryModule.Get().GetAncestorClassNames(AssetData.AssetClass, AncestorClassNames);
-		if (!AncestorClassNames.Contains(UBlueprintCore::StaticClass()->GetFName()))
+		TArray<FTopLevelAssetPath> AncestorClassNames;
+		AssetRegistryModule.Get().GetAncestorClassNames(AssetData.AssetClassPath, AncestorClassNames);
+		if (!AncestorClassNames.Contains(UBlueprintCore::StaticClass()->GetClassPathName()))
 		{
 			return;
 		}
@@ -439,7 +439,7 @@ void UFlowGraphSchema::AddAsset(const FAssetData& AssetData, const bool bBatch)
 		{
 			UObject* Outer = nullptr;
 			ResolveName(Outer, NativeParentClassPath, false, false);
-			const UClass* NativeParentClass = FindObject<UClass>(ANY_PACKAGE, *NativeParentClassPath);
+			const UClass* NativeParentClass = FindObject<UClass>(nullptr, *NativeParentClassPath);
 
 			// accept only Flow Node blueprints
 			if (NativeParentClass && NativeParentClass->IsChildOf(UFlowNode::StaticClass()))

--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -24,9 +24,11 @@
 #include "Styling/SlateColor.h"
 #include "TutorialMetaData.h"
 #include "Widgets/Images/SImage.h"
+#include "Widgets/Input/SButton.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/SBoxPanel.h"
 #include "Widgets/SOverlay.h"
+#include "Widgets/SToolTip.h"
 
 #define LOCTEXT_NAMESPACE "SFlowGraphNode"
 
@@ -360,7 +362,7 @@ void SFlowGraphNode::UpdateErrorInfo()
 		if (FlowNode->GetClass()->HasAnyClassFlags(CLASS_Deprecated) || FlowNode->bNodeDeprecated)
 		{
 			ErrorMsg = FlowNode->ReplacedBy ? FString::Printf(TEXT(" REPLACED BY: %s "), *FlowNode->ReplacedBy->GetName()) : FString(TEXT(" DEPRECATED! "));
-			ErrorColor = FEditorStyle::GetColor("ErrorReporting.WarningBackgroundColor");
+			ErrorColor = FAppStyle::GetColor("ErrorReporting.WarningBackgroundColor");
 			return;
 		}
 	}
@@ -371,7 +373,7 @@ void SFlowGraphNode::UpdateErrorInfo()
 TSharedRef<SWidget> SFlowGraphNode::CreateNodeContentArea()
 {
 	return SNew(SBorder)
-		.BorderImage(FEditorStyle::GetBrush("NoBorder"))
+		.BorderImage(FAppStyle::GetBrush("NoBorder"))
 		.HAlign(HAlign_Fill)
 		.VAlign(VAlign_Fill)
 		[
@@ -440,7 +442,7 @@ void SFlowGraphNode::CreateInputSideAddButton(TSharedPtr<SVerticalBox> OutputBox
 		. Padding( 0,0,7,0 )
 		[
 			SNew(SImage)
-			.Image(FEditorStyle::GetBrush(TEXT("Icons.PlusCircle")))
+			.Image(FAppStyle::GetBrush(TEXT("Icons.PlusCircle")))
 		]
 		+SHorizontalBox::Slot()
 		.AutoWidth()
@@ -475,7 +477,7 @@ void SFlowGraphNode::CreateOutputSideAddButton(TSharedPtr<SVerticalBox> OutputBo
 		.Padding(7,0,0,0)
 		[
 			SNew(SImage)
-			.Image(FEditorStyle::GetBrush(TEXT("Icons.PlusCircle")))
+			.Image(FAppStyle::GetBrush(TEXT("Icons.PlusCircle")))
 		];
 
 		AddPinButton(OutputBox, AddPinWidget.ToSharedRef(), EGPD_Output);
@@ -498,7 +500,7 @@ void SFlowGraphNode::AddPinButton(TSharedPtr<SVerticalBox> OutputBox, const TSha
 
 	const TSharedRef<SButton> AddPinButton = SNew(SButton)
 	.ContentPadding(0.0f)
-	.ButtonStyle(FEditorStyle::Get(), "NoBorder")
+	.ButtonStyle(FAppStyle::Get(), "NoBorder")
 	.OnClicked(this, &SFlowGraphNode::OnAddFlowPin, Direction)
 	.IsEnabled(this, &SFlowGraphNode::IsNodeEditable)
 	.ToolTipText(PinTooltipText)

--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode_SubGraph.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode_SubGraph.cpp
@@ -8,6 +8,7 @@
 
 #include "IDocumentation.h"
 #include "SGraphPreviewer.h"
+#include "Widgets/Layout/SBox.h"
 #include "Widgets/SToolTip.h"
 
 #define LOCTEXT_NAMESPACE "SFlowGraphNode_SubGraph"

--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowPalette.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowPalette.cpp
@@ -47,7 +47,7 @@ void SFlowPaletteItem::Construct(const FArguments& InArgs, FCreateWidgetForActio
 	}
 
 	// Find icons
-	const FSlateBrush* IconBrush = FEditorStyle::GetBrush(TEXT("NoBrush"));
+	const FSlateBrush* IconBrush = FAppStyle::GetBrush(TEXT("NoBrush"));
 	const FSlateColor IconColor = FSlateColor::UseForeground();
 	const FText IconToolTip = GraphAction->GetTooltipDescription();
 	constexpr bool bIsReadOnly = false;
@@ -110,7 +110,7 @@ void SFlowPalette::Construct(const FArguments& InArgs, TWeakPtr<FFlowAssetEditor
 	[
 		SNew(SBorder)
 			.Padding(2.0f)
-			.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 			[
 				SNew(SVerticalBox)
 				+ SVerticalBox::Slot() // Filter UI

--- a/Source/FlowEditor/Private/MovieScene/FlowSection.cpp
+++ b/Source/FlowEditor/Private/MovieScene/FlowSection.cpp
@@ -33,9 +33,9 @@ void FFlowSectionBase::PaintEventName(FSequencerSectionPainter& Painter, int32 L
 	static const float BoxOffsetPx = 10.f;
 	static const TCHAR* WarningString = TEXT("\xf071");
 
-	const FSlateFontInfo FontAwesomeFont = FEditorStyle::Get().GetFontStyle("FontAwesome.10");
+	const FSlateFontInfo FontAwesomeFont = FAppStyle::Get().GetFontStyle("FontAwesome.10");
 	const FSlateFontInfo SmallLayoutFont = FCoreStyle::GetDefaultFontStyle("Bold", 10);
-	const FLinearColor DrawColor = FEditorStyle::GetSlateColor("SelectionColor").GetColor(FWidgetStyle());
+	const FLinearColor DrawColor = FAppStyle::GetSlateColor("SelectionColor").GetColor(FWidgetStyle());
 
 	TSharedRef<FSlateFontMeasure> FontMeasureService = FSlateApplication::Get().GetRenderer()->GetFontMeasureService();
 
@@ -66,7 +66,7 @@ void FFlowSectionBase::PaintEventName(FSequencerSectionPainter& Painter, int32 L
 		Painter.DrawElements,
 		LayerId + 1,
 		Painter.SectionGeometry.ToPaintGeometry(BoxOffset, BoxSize),
-		FEditorStyle::GetBrush("WhiteBrush"),
+		FAppStyle::GetBrush("WhiteBrush"),
 		ESlateDrawEffect::None,
 		FLinearColor::Black.CopyWithNewOpacity(0.5f)
 	);
@@ -81,7 +81,7 @@ void FFlowSectionBase::PaintEventName(FSequencerSectionPainter& Painter, int32 L
 			WarningString,
 			FontAwesomeFont,
 			Painter.bParentEnabled ? ESlateDrawEffect::None : ESlateDrawEffect::DisabledEffect,
-			FEditorStyle::GetWidgetStyle<FTextBlockStyle>("Log.Warning").ColorAndOpacity.GetSpecifiedColor()
+			FAppStyle::GetWidgetStyle<FTextBlockStyle>("Log.Warning").ColorAndOpacity.GetSpecifiedColor()
 		);
 	}
 

--- a/Source/FlowEditor/Private/MovieScene/FlowTrackEditor.cpp
+++ b/Source/FlowEditor/Private/MovieScene/FlowTrackEditor.cpp
@@ -76,7 +76,7 @@ void FFlowTrackEditor::BuildAddTrackMenu(FMenuBuilder& MenuBuilder)
 			LOCTEXT("AddTooltip", "Adds a new flow track that can trigger events in the Flow graph."),
 			FNewMenuDelegate::CreateRaw(this, &FFlowTrackEditor::AddFlowSubMenu),
 			false,
-			FSlateIcon(FEditorStyle::GetStyleSetName(), "Sequencer.Tracks.Event")
+			FSlateIcon(FAppStyle::GetAppStyleSetName(), "Sequencer.Tracks.Event")
 		);
 	}
 }
@@ -144,7 +144,7 @@ bool FFlowTrackEditor::SupportsSequence(UMovieSceneSequence* InSequence) const
 
 const FSlateBrush* FFlowTrackEditor::GetIconBrush() const
 {
-	return FEditorStyle::GetBrush("Sequencer.Tracks.Event");
+	return FAppStyle::GetBrush("Sequencer.Tracks.Event");
 }
 
 void FFlowTrackEditor::HandleAddFlowTrackMenuEntryExecute(UClass* SectionType)

--- a/Source/FlowEditor/Private/MovieScene/FlowTrackEditor.cpp
+++ b/Source/FlowEditor/Private/MovieScene/FlowTrackEditor.cpp
@@ -138,7 +138,7 @@ bool FFlowTrackEditor::SupportsType(TSubclassOf<UMovieSceneTrack> Type) const
 
 bool FFlowTrackEditor::SupportsSequence(UMovieSceneSequence* InSequence) const
 {
-	static UClass* LevelSequenceClass = FindObject<UClass>(ANY_PACKAGE, TEXT("LevelSequence"), true);
+	static UClass* LevelSequenceClass = FindObject<UClass>(nullptr, TEXT("LevelSequence"), true);
 	return InSequence && LevelSequenceClass && InSequence->GetClass()->IsChildOf(LevelSequenceClass);
 }
 

--- a/Source/FlowEditor/Private/Nodes/FlowNodeBlueprintFactory.cpp
+++ b/Source/FlowEditor/Private/Nodes/FlowNodeBlueprintFactory.cpp
@@ -45,7 +45,7 @@ public:
 		[
 			SNew(SBorder)
 				.Visibility(EVisibility::Visible)
-				.BorderImage(FEditorStyle::GetBrush("Menu.Background"))
+				.BorderImage(FAppStyle::GetBrush("Menu.Background"))
 				[
 					SNew(SBox)
 						.Visibility(EVisibility::Visible)
@@ -56,7 +56,7 @@ public:
 								.FillHeight(1)
 								[
 									SNew(SBorder)
-										.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+										.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 										.Content()
 										[
 											SAssignNew(ParentClassContainer, SVerticalBox)
@@ -69,14 +69,14 @@ public:
 								.Padding(8)
 								[
 									SNew(SUniformGridPanel)
-										.SlotPadding(FEditorStyle::GetMargin("StandardDialog.SlotPadding"))
-										.MinDesiredSlotWidth(FEditorStyle::GetFloat("StandardDialog.MinDesiredSlotWidth"))
-										.MinDesiredSlotHeight(FEditorStyle::GetFloat("StandardDialog.MinDesiredSlotHeight"))
+										.SlotPadding(FAppStyle::GetMargin("StandardDialog.SlotPadding"))
+										.MinDesiredSlotWidth(FAppStyle::GetFloat("StandardDialog.MinDesiredSlotWidth"))
+										.MinDesiredSlotHeight(FAppStyle::GetFloat("StandardDialog.MinDesiredSlotHeight"))
 										+ SUniformGridPanel::Slot(0, 0)
 											[
 												SNew(SButton)
 													.HAlign(HAlign_Center)
-													.ContentPadding(FEditorStyle::GetMargin("StandardDialog.ContentPadding"))
+													.ContentPadding(FAppStyle::GetMargin("StandardDialog.ContentPadding"))
 													.OnClicked(this, &SFlowNodeBlueprintCreateDialog::OkClicked)
 													.Text(LOCTEXT("CreateFlowNodeBlueprintOk", "OK"))
 											]
@@ -84,7 +84,7 @@ public:
 											[
 												SNew(SButton)
 													.HAlign(HAlign_Center)
-													.ContentPadding(FEditorStyle::GetMargin("StandardDialog.ContentPadding"))
+													.ContentPadding(FAppStyle::GetMargin("StandardDialog.ContentPadding"))
 													.OnClicked(this, &SFlowNodeBlueprintCreateDialog::CancelClicked)
 													.Text(LOCTEXT("CreateFlowNodeBlueprintCancel", "Cancel"))
 											]

--- a/Source/FlowEditor/Public/Asset/FlowAssetToolbar.h
+++ b/Source/FlowEditor/Public/Asset/FlowAssetToolbar.h
@@ -8,6 +8,7 @@
 #include "FlowAsset.h"
 
 class FFlowAssetEditor;
+class UToolMenu;
 
 //////////////////////////////////////////////////////////////////////////
 // Flow Asset Instance List

--- a/Source/FlowEditor/Public/FlowEditorModule.h
+++ b/Source/FlowEditor/Public/FlowEditorModule.h
@@ -3,8 +3,11 @@
 #pragma once
 
 #include "AssetTypeCategories.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "IAssetTypeActions.h"
 #include "Modules/ModuleInterface.h"
+#include "PropertyEditorDelegates.h"
+#include "Toolkits/IToolkit.h"
 
 class FSlateStyleSet;
 struct FGraphPanelPinConnectionFactory;


### PR DESCRIPTION
…and add missing forward declarations and includes to fix unity compile issues

Main branch of unreal removed `FEditorStyle` stating that `FAppStyle` should be used instead and I was hitting a bunch of compile errors due to missing includes/forward declarations