### PR TITLE
Asset category merge by name

### DIFF
--- a/Source/FlowEditor/Private/FlowEditorModule.cpp
+++ b/Source/FlowEditor/Private/FlowEditorModule.cpp
@@ -120,7 +120,29 @@ void FFlowEditorModule::ShutdownModule()
 void FFlowEditorModule::RegisterAssets()
 {
 	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
-	FlowAssetCategory = AssetTools.RegisterAdvancedAssetCategory(FName(TEXT("Flow")), UFlowGraphSettings::Get()->FlowAssetCategoryName);
+
+	FText AssetCategoryText = UFlowGraphSettings::Get()->FlowAssetCategoryName;
+
+	// Find matching BuildIn category
+	if (!AssetCategoryText.IsEmpty())
+	{		
+		TArray<FAdvancedAssetCategory> AllCategories;
+		AssetTools.GetAllAdvancedAssetCategories(AllCategories);
+		for (const FAdvancedAssetCategory& ExistingCategory : AllCategories)
+		{
+			if (ExistingCategory.CategoryName.EqualTo(AssetCategoryText))
+			{
+				FlowAssetCategory = ExistingCategory.CategoryType;
+				break;
+			}
+		}
+	}
+
+	if (FlowAssetCategory == EAssetTypeCategories::None)
+	{
+		FlowAssetCategory = AssetTools.RegisterAdvancedAssetCategory(FName(TEXT("Flow")), AssetCategoryText);
+	}
+
 
 	const TSharedRef<IAssetTypeActions> FlowAssetActions = MakeShareable(new FAssetTypeActions_FlowAsset());
 	RegisteredAssetActions.Add(FlowAssetActions);

--- a/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
@@ -19,20 +19,20 @@ class UFlowGraphSettings final : public UDeveloperSettings
 
 	/** Show Flow Asset in Flow category of "Create Asset" menu?
 	* Requires restart after making a change. */
-	UPROPERTY(EditAnywhere, config, Category = "Default UI")
+	UPROPERTY(EditAnywhere, config, Category = "Default UI", meta = (ConfigRestartRequired = true))
 	bool bExposeFlowAssetCreation;
 
 	/** Show Flow Node blueprint in Flow category of "Create Asset" menu?
 	* Requires restart after making a change. */
-	UPROPERTY(EditAnywhere, config, Category = "Default UI")
+	UPROPERTY(EditAnywhere, config, Category = "Default UI", meta = (ConfigRestartRequired = true))
 	bool bExposeFlowNodeCreation;
 	
 	/** Show Flow Asset toolbar?
 	* Requires restart after making a change. */
-	UPROPERTY(EditAnywhere, config, Category = "Default UI")
+	UPROPERTY(EditAnywhere, config, Category = "Default UI", meta = (ConfigRestartRequired = true))
 	bool bShowAssetToolbarAboveLevelEditor;
 
-	UPROPERTY(EditAnywhere, config, Category = "Default UI")
+	UPROPERTY(EditAnywhere, config, Category = "Default UI", meta = (ConfigRestartRequired = true))
 	FText FlowAssetCategoryName;
 
 	/** Flow Asset class allowed to be assigned via Level Editor toolbar*/


### PR DESCRIPTION
This will allow to reuse BuiltIn categories. eg Gameplay. 
And it'll show pop up "Require restart" when changing relevant settings

Merging is kinda random when it comes to other plugins with custom categories, but if other plugin loads first or has similar merger it will share menu category
