### PR TITLE
Class picker for new assets

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetFactory.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetFactory.cpp
@@ -4,6 +4,56 @@
 #include "FlowAsset.h"
 #include "Graph/FlowGraph.h"
 
+#include <ClassViewerModule.h>
+#include <ClassViewerFilter.h>
+#include <Kismet2/KismetEditorUtilities.h>
+#include <Kismet2/SClassPickerDialog.h>
+
+
+class FAssetClassParentFilter : public IClassViewerFilter
+{
+public:
+	FAssetClassParentFilter()
+		: DisallowedClassFlags(CLASS_None), bDisallowBlueprintBase(false)
+	{}
+
+	/** All children of these classes will be included unless filtered out by another setting. */
+	TSet< const UClass* > AllowedChildrenOfClasses;
+
+	/** Disallowed class flags. */
+	EClassFlags DisallowedClassFlags;
+
+	/** Disallow blueprint base classes. */
+	bool bDisallowBlueprintBase;
+
+	virtual bool IsClassAllowed(const FClassViewerInitializationOptions& InInitOptions, const UClass* InClass, TSharedRef< FClassViewerFilterFuncs > InFilterFuncs) override
+	{
+		bool bAllowed = !InClass->HasAnyClassFlags(DisallowedClassFlags)
+			&& InFilterFuncs->IfInChildOfClassesSet(AllowedChildrenOfClasses, InClass) != EFilterReturn::Failed;
+
+		if (bAllowed && bDisallowBlueprintBase)
+		{
+			if (FKismetEditorUtilities::CanCreateBlueprintOfClass(InClass))
+			{
+				return false;
+			}
+		}
+
+		return bAllowed;
+	}
+
+	virtual bool IsUnloadedClassAllowed(const FClassViewerInitializationOptions& InInitOptions, const TSharedRef< const IUnloadedBlueprintData > InUnloadedClassData, TSharedRef< FClassViewerFilterFuncs > InFilterFuncs) override
+	{
+		if (bDisallowBlueprintBase)
+		{
+			return false;
+		}
+
+		return !InUnloadedClassData->HasAnyClassFlags(DisallowedClassFlags)
+			&& InFilterFuncs->IfInChildOfClassesSet(AllowedChildrenOfClasses, InUnloadedClassData) != EFilterReturn::Failed;
+	}
+};
+
 UFlowAssetFactory::UFlowAssetFactory(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
@@ -14,9 +64,54 @@ UFlowAssetFactory::UFlowAssetFactory(const FObjectInitializer& ObjectInitializer
 	bEditAfterNew = true;
 }
 
+bool UFlowAssetFactory::ConfigureProperties()
+{
+	AssetClass = UFlowGraphSettings::Get()->DefaultFlowAssetClass;;
+
+	if (AssetClass != nullptr)
+	{		
+		// Class was selected in settings
+		return true;
+	}
+
+	// Load the classviewer module to display a class picker
+	FClassViewerModule& ClassViewerModule = FModuleManager::LoadModuleChecked<FClassViewerModule>("ClassViewer");
+
+	// Fill in options
+	FClassViewerInitializationOptions Options;
+	Options.Mode = EClassViewerMode::ClassPicker;
+
+	TSharedPtr<FAssetClassParentFilter> Filter = MakeShareable(new FAssetClassParentFilter);
+	Options.ClassFilter = Filter;
+
+	Filter->DisallowedClassFlags = CLASS_Abstract | CLASS_Deprecated | CLASS_NewerVersionExists | CLASS_HideDropDown;
+	Filter->AllowedChildrenOfClasses.Add(UFlowAsset::StaticClass());
+
+	const FText TitleText = NSLOCTEXT("FlowAssetFactory", "CreateFlowAssetOptions", "Pick Flow Asset Class");
+	UClass* ChosenClass = nullptr;
+	const bool bPressedOk = SClassPickerDialog::PickClass(TitleText, Options, ChosenClass, UFlowAsset::StaticClass());
+
+	if (bPressedOk)
+	{
+		AssetClass = ChosenClass;
+	}
+
+	return bPressedOk;
+}
+
 UObject* UFlowAssetFactory::FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
 {
-	UFlowAsset* NewFlow = NewObject<UFlowAsset>(InParent, Class, Name, Flags | RF_Transactional, Context);
+	UFlowAsset* NewFlow = nullptr;
+	if (AssetClass != nullptr)
+	{
+		NewFlow = NewObject<UFlowAsset>(InParent, AssetClass, Name, Flags | RF_Transactional, Context);
+	}
+	else
+	{
+		// if we have no asset class, use the passed-in class instead
+		NewFlow = NewObject<UFlowAsset>(InParent, Class, Name, Flags | RF_Transactional, Context);
+	}
+
 	UFlowGraph::CreateGraph(NewFlow);
 	return NewFlow;
 }

--- a/Source/FlowEditor/Private/Graph/FlowGraphSettings.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSettings.cpp
@@ -12,6 +12,7 @@ UFlowGraphSettings::UFlowGraphSettings(const FObjectInitializer& ObjectInitializ
 	, bExposeFlowNodeCreation(true)
 	, bShowAssetToolbarAboveLevelEditor(true)
 	, FlowAssetCategoryName(LOCTEXT("FlowAssetCategory", "Flow"))
+	, DefaultFlowAssetClass(UFlowAsset::StaticClass())
 	, WorldAssetClass(UFlowAsset::StaticClass())
 	, bShowDefaultPinNames(false)
 	, ExecPinColorModifier(0.75f, 0.75f, 0.75f, 1.0f)

--- a/Source/FlowEditor/Public/Asset/FlowAssetFactory.h
+++ b/Source/FlowEditor/Public/Asset/FlowAssetFactory.h
@@ -10,5 +10,9 @@ class UFlowAssetFactory : public UFactory
 {
 	GENERATED_UCLASS_BODY()
 
+	UPROPERTY(EditAnywhere, Category = Asset)
+	TSubclassOf<class UFlowAsset> AssetClass;
+
+	virtual bool ConfigureProperties() override;
 	virtual UObject* FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
 };

--- a/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
@@ -35,6 +35,10 @@ class UFlowGraphSettings final : public UDeveloperSettings
 	UPROPERTY(EditAnywhere, config, Category = "Default UI")
 	FText FlowAssetCategoryName;
 
+	/** Use this class to create new assets. Class picker will show up if None */
+	UPROPERTY(EditAnywhere, config, Category = "Default UI")
+	TSubclassOf<class UFlowAsset> DefaultFlowAssetClass;
+
 	/** Flow Asset class allowed to be assigned via Level Editor toolbar*/
 	UPROPERTY(EditAnywhere, config, Category = "Default UI", meta = (EditCondition = "bShowAssetToolbarAboveLevelEditor"))
 	TSubclassOf<class UFlowAsset> WorldAssetClass;


### PR DESCRIPTION
Just a helpful class selector when you have multiple asset classes like with DataAssets. 
It's fully optional and disabled by default

I'm quite sure most of people who have created quest or dialogue systems have implemented some form of this
