### PR TITLE
Custom output finish

### DIFF
--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -406,9 +406,9 @@ void UFlowAsset::TriggerCustomEvent(UFlowNode_SubGraph* Node, const FName& Event
 	}
 }
 
-void UFlowAsset::TriggerCustomOutput(const FName& EventName) const
+void UFlowAsset::TriggerCustomOutput(const FName& EventName, const bool bFinish) const
 {
-	NodeOwningThisAssetInstance->TriggerOutput(EventName);
+	NodeOwningThisAssetInstance->TriggerOutput(EventName, bFinish);
 }
 
 void UFlowAsset::TriggerInput(const FGuid& NodeGuid, const FName& PinName)

--- a/Source/Flow/Private/Nodes/Route/FlowNode_CustomOutput.cpp
+++ b/Source/Flow/Private/Nodes/Route/FlowNode_CustomOutput.cpp
@@ -7,6 +7,7 @@
 
 UFlowNode_CustomOutput::UFlowNode_CustomOutput(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
+	, bFinish(false)
 {
 #if WITH_EDITOR
 	Category = TEXT("Route");
@@ -20,13 +21,13 @@ void UFlowNode_CustomOutput::ExecuteInput(const FName& PinName)
 {
 	if (!EventName.IsNone() && GetFlowAsset()->GetCustomOutputs().Contains(EventName) && GetFlowAsset()->GetNodeOwningThisAssetInstance())
 	{
-		GetFlowAsset()->TriggerCustomOutput(EventName);
+		GetFlowAsset()->TriggerCustomOutput(EventName, bFinish);
 	}
 }
 
 #if WITH_EDITOR
 FString UFlowNode_CustomOutput::GetNodeDescription() const
 {
-	return EventName.ToString();
+	return EventName.ToString() + LINE_TERMINATOR + (bFinish ? TEXT("True") : TEXT("False"));
 }
 #endif

--- a/Source/Flow/Private/Nodes/Route/FlowNode_CustomOutput.cpp
+++ b/Source/Flow/Private/Nodes/Route/FlowNode_CustomOutput.cpp
@@ -7,7 +7,7 @@
 
 UFlowNode_CustomOutput::UFlowNode_CustomOutput(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
-	, bFinish(false)
+	, bFinishGraph(false)
 {
 #if WITH_EDITOR
 	Category = TEXT("Route");
@@ -21,13 +21,13 @@ void UFlowNode_CustomOutput::ExecuteInput(const FName& PinName)
 {
 	if (!EventName.IsNone() && GetFlowAsset()->GetCustomOutputs().Contains(EventName) && GetFlowAsset()->GetNodeOwningThisAssetInstance())
 	{
-		GetFlowAsset()->TriggerCustomOutput(EventName, bFinish);
+		GetFlowAsset()->TriggerCustomOutput(EventName, bFinishGraph);
 	}
 }
 
 #if WITH_EDITOR
 FString UFlowNode_CustomOutput::GetNodeDescription() const
 {
-	return EventName.ToString() + LINE_TERMINATOR + (bFinish ? TEXT("True") : TEXT("False"));
+	return EventName.ToString() + LINE_TERMINATOR + (bFinishGraph ? TEXT("True") : TEXT("False"));
 }
 #endif

--- a/Source/Flow/Private/Nodes/Route/FlowNode_SubGraph.cpp
+++ b/Source/Flow/Private/Nodes/Route/FlowNode_SubGraph.cpp
@@ -18,7 +18,7 @@ UFlowNode_SubGraph::UFlowNode_SubGraph(const FObjectInitializer& ObjectInitializ
 #endif
 
 	InputPins = {StartPin};
-	OutputPins = {FinishPin};
+	OutputPins = {};
 }
 
 bool UFlowNode_SubGraph::CanBeAssetInstanced() const

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -247,7 +247,7 @@ public:
 
 private:
 	void TriggerCustomEvent(UFlowNode_SubGraph* Node, const FName& EventName) const;
-	void TriggerCustomOutput(const FName& EventName) const;
+	void TriggerCustomOutput(const FName& EventName, const bool bFinish) const;
 
 	void TriggerInput(const FGuid& NodeGuid, const FName& PinName);
 

--- a/Source/Flow/Public/Nodes/Route/FlowNode_CustomOutput.h
+++ b/Source/Flow/Public/Nodes/Route/FlowNode_CustomOutput.h
@@ -17,8 +17,9 @@ class FLOW_API UFlowNode_CustomOutput final : public UFlowNode
 	UPROPERTY()
 	FName EventName;
 
+	// this allows to finish execution of this Flow Asset
 	UPROPERTY(EditAnywhere, Category = "Output")
-	bool bFinish;
+	bool bFinishGraph;
 	
 protected:
 	virtual void ExecuteInput(const FName& PinName) override;

--- a/Source/Flow/Public/Nodes/Route/FlowNode_CustomOutput.h
+++ b/Source/Flow/Public/Nodes/Route/FlowNode_CustomOutput.h
@@ -16,6 +16,9 @@ class FLOW_API UFlowNode_CustomOutput final : public UFlowNode
 
 	UPROPERTY()
 	FName EventName;
+
+	UPROPERTY(EditAnywhere, Category = "Output")
+	bool bFinish;
 	
 protected:
 	virtual void ExecuteInput(const FName& PinName) override;


### PR DESCRIPTION
The default subgraph output pin (`finish`) feels kind of limitative. Often times, I'd like to rename it for a more descriptive name or make another `finish` output pin, which would allow me to finish the subgraph at the same time as I trigger an output pin in a different context. Just like a flow node using `TriggerOutput`, it's up to the individual output pins to decide whether or not to finish the current flow graph in my opinion. What do you think?