### PR TITLE
On node input triggered/output triggered

### DIFF
--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -48,6 +48,14 @@ void UFlowSubsystem::Deinitialize()
 	AbortActiveFlows();
 }
 
+void UFlowSubsystem::OnNodeInputTriggered(const UFlowNode* node, const bool bWasActive)
+{
+}
+
+void UFlowSubsystem::OnNodeOutputTriggered(const UFlowNode* node, const bool bFinish)
+{
+}
+
 void UFlowSubsystem::AbortActiveFlows()
 {
 	if (InstancedTemplates.Num() > 0)

--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -346,6 +346,8 @@ void UFlowNode::TriggerInput(const FName& PinName, const bool bForcedActivation 
 
 		ActivationState = EFlowNodeState::Active;
 
+		GetFlowSubsystem()->OnNodeInputTriggered(this, PreviousActivationState == EFlowNodeState::Active);
+
 #if !UE_BUILD_SHIPPING
 		// record for debugging
 		TArray<FPinRecord>& Records = InputRecords.FindOrAdd(PinName);
@@ -385,6 +387,8 @@ void UFlowNode::TriggerFirstOutput(const bool bFinish)
 
 void UFlowNode::TriggerOutput(const FName& PinName, const bool bFinish /*= false*/, const bool bForcedActivation /*= false*/)
 {
+	GetFlowSubsystem()->OnNodeOutputTriggered(this, bFinish);
+
 	// clean up node, if needed
 	if (bFinish)
 	{

--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -338,6 +338,12 @@ void UFlowNode::TriggerInput(const FName& PinName, const bool bForcedActivation 
 {
 	if (InputPins.Contains(PinName))
 	{
+		EFlowNodeState PreviousActivationState = ActivationState;
+		if (PreviousActivationState != EFlowNodeState::Active)
+		{
+			Activate();
+		}
+
 		ActivationState = EFlowNodeState::Active;
 
 #if !UE_BUILD_SHIPPING
@@ -456,6 +462,11 @@ void UFlowNode::Deactivate()
 void UFlowNode::Cleanup()
 {
 	K2_Cleanup();
+}
+
+void UFlowNode::Activate()
+{
+	K2_Activate();
 }
 
 void UFlowNode::ForceFinishNode()

--- a/Source/Flow/Public/FlowSubsystem.h
+++ b/Source/Flow/Public/FlowSubsystem.h
@@ -12,6 +12,7 @@
 
 class UFlowAsset;
 class UFlowNode_SubGraph;
+class UFlowNode;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FSimpleFlowEvent);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FSimpleFlowComponentEvent, UFlowComponent*, Component);
@@ -59,6 +60,9 @@ public:
 
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
+
+	virtual void OnNodeInputTriggered(const UFlowNode* node, const bool bWasActive);
+	virtual void OnNodeOutputTriggered(const UFlowNode* node, const bool bFinish);
 
 	virtual void AbortActiveFlows();
 

--- a/Source/Flow/Public/Nodes/FlowNode.h
+++ b/Source/Flow/Public/Nodes/FlowNode.h
@@ -280,6 +280,11 @@ protected:
 	UFUNCTION(BlueprintImplementableEvent, Category = "FlowNode", meta = (DisplayName = "Cleanup"))
 	void K2_Cleanup();
 
+	virtual void Activate();
+
+	UFUNCTION(BlueprintImplementableEvent, Category = "FlowNode", meta = (DisplayName = "Activate"))
+	void K2_Activate();
+
 public:
 	// Define what happens when node is terminated from the outside
 	virtual void ForceFinishNode();


### PR DESCRIPTION
Added an `Activate` function. Currently, there's no proper `Initialize` function. Although we do have `InitializeInstance`, it only gets called once, unlike `Cleanup`. Let's say I initialize an object in `InitializeInstance` (`Object = NewObject()`) and I clean it up in `Cleanup` (`Object = nullptr`). I might still end up with `nullptr` if the flow node has already been cleaned up and I tried to trigger the same flow node again. I've noticed that some of the native flow nodes initialize its member variable in `ExecuteInput`. But I feel like having a proper `Initialize` function would be helpful, just like `BeginPlay/EndPlay` in `AActor`. What do you think?

`OnNodeInputTriggered` and `OnNodeOutputTriggered` allow us to do something (e.g. logging) whenever a flow node has its input/output pin triggered.