### PR TITLE
Improve drawing for reroute nodes that go backwards

### DIFF
--- a/Source/FlowEditor/Public/Graph/FlowGraphConnectionDrawingPolicy.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphConnectionDrawingPolicy.h
@@ -45,6 +45,9 @@ class FLOWEDITOR_API FFlowGraphConnectionDrawingPolicy : public FConnectionDrawi
 	TMap<UEdGraphPin*, UEdGraphPin*> RecordedPaths;
 	TMap<UEdGraphPin*, UEdGraphPin*> SelectedPaths;
 
+	//Used to help reversing pins on nodes that go backwards
+	TMap<class UFlowGraphNode_Reroute*, bool> RerouteToReversedDirectionMap;
+
 public:
 	FFlowGraphConnectionDrawingPolicy(int32 InBackLayerID, int32 InFrontLayerID, float ZoomFactor, const FSlateRect& InClippingRect, FSlateWindowElementList& InDrawElements, UEdGraph* InGraphObj);
 
@@ -60,4 +63,8 @@ protected:
 	void DrawCircuitSpline(const int32& LayerId, const FVector2D& Start, const FVector2D& End, const FConnectionParams& Params) const;
 	void DrawCircuitConnection(const int32& LayerId, const FVector2D& Start, const FVector2D& StartDirection, const FVector2D& End, const FVector2D& EndDirection, const FConnectionParams& Params) const;
 	static FVector2D GetControlPoint(const FVector2D& Source, const FVector2D& Target);
+
+	bool ShouldChangeTangentForReroute(class UFlowGraphNode_Reroute* Reroute);
+	bool FindPinCenter(UEdGraphPin* Pin, FVector2D& OutCenter) const;
+	bool GetAverageConnectedPosition(class UFlowGraphNode_Reroute* Reroute, EEdGraphPinDirection Direction, FVector2D& OutPos) const;
 };


### PR DESCRIPTION
This changes the drawing algo for reroute nodes so that they handle going "backwards" in the graph in a nicer way.

The code is copied and adapted from `FKismetConnectionDrawingPolicy` (`BlueprintConnectionDrawingPolicy.cpp/.h`). The functions are mostly the same, except for minor changes so they work with `UFlowGraphNode_Reroute`s instead of `UK2Node_Knot`s

Tested to compile and work against both `main` and `4.27` branches.

Before: 
![chrome_UNvAlUSZ8X](https://user-images.githubusercontent.com/144132/192101503-a9ab7164-b7b9-448c-8ccf-832cfd60ce02.png)

After: 
![UE4Editor-Win64-DebugGame_iEX3Z9fSpJ](https://user-images.githubusercontent.com/144132/192101506-4ef2a323-3656-4178-a088-70f9504d0b19.png)
