### PR TITLE
Hide advanced pins for specific flow node classes

### DIFF
--- a/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
@@ -59,6 +59,10 @@ class UFlowGraphSettings final : public UDeveloperSettings
 	UPROPERTY(Config, EditAnywhere, Category = "Nodes")
 	TMap<TSubclassOf<UFlowNode>, FLinearColor> NodeSpecificColors;
 
+	/** Hide unused pins whose index is greater than the given threshold */
+	UPROPERTY(Config, EditAnywhere, Category = "Nodes")
+	TMap<TSubclassOf<UFlowNode>, int32> NodeHideAdvancedPinThresholds;
+
 	UPROPERTY(EditAnywhere, config, Category = "Nodes")
 	FLinearColor ExecPinColorModifier;
 


### PR DESCRIPTION
It could come in handy if you have a flow node with a lot of pins. What do you think?