### PR TITLE
Mark asset as dirty after changing signal mode

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
@@ -1265,6 +1265,8 @@ void FFlowAssetEditor::SetSignalMode(const EFlowSignalMode Mode) const
 	{
 		SelectedNode->SetSignalMode(Mode);
 	}
+
+	FlowAsset->Modify();
 }
 
 bool FFlowAssetEditor::CanSetSignalMode(const EFlowSignalMode Mode) const


### PR DESCRIPTION
After changing signal mode, flow asset needs to be saved for the signal mode changes to take effect next time you open it. This change will mark the asset dirty so the developer knows.