### PR TITLE
Use in-built SetEnabledState instead of overriding non-virtual methods

### DIFF
--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -1074,6 +1074,7 @@ void UFlowGraphNode::SetSignalMode(const EFlowSignalMode Mode)
 	if (FlowNode)
 	{
 		FlowNode->SignalMode = Mode;
+		SetEnabledState(Mode == EFlowSignalMode::Enabled ? ENodeEnabledState::Enabled : ENodeEnabledState::Disabled);
 		OnSignalModeChanged.ExecuteIfBound();
 	}
 }

--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -415,52 +415,6 @@ const FSlateBrush* SFlowGraphNode::GetNodeBodyBrush() const
 	return FFlowEditorStyle::GetBrush("Flow.Node.Body");
 }
 
-FSlateColor SFlowGraphNode::GetNodeTitleColor() const
-{
-	FLinearColor ReturnTitleColor = GraphNode->IsDeprecated() ? FLinearColor::Red : GetNodeObj()->GetNodeTitleColor();
-
-	if (FlowGraphNode->GetSignalMode() == EFlowSignalMode::Enabled)
-	{
-		ReturnTitleColor.A = FadeCurve.GetLerp();
-	}
-	else
-	{
-		ReturnTitleColor *= FLinearColor(0.5f, 0.5f, 0.5f, 0.4f);
-	}
-
-	return ReturnTitleColor;
-}
-
-FSlateColor SFlowGraphNode::GetNodeBodyColor() const
-{
-	FLinearColor ReturnBodyColor = GraphNode->GetNodeBodyTintColor();
-	if (FlowGraphNode->GetSignalMode() != EFlowSignalMode::Enabled)
-	{
-		ReturnBodyColor *= FLinearColor(1.0f, 1.0f, 1.0f, 0.5f); 
-	}
-	return ReturnBodyColor;
-}
-
-FSlateColor SFlowGraphNode::GetNodeTitleIconColor() const
-{
-	FLinearColor ReturnIconColor = IconColor;
-	if (FlowGraphNode->GetSignalMode() != EFlowSignalMode::Enabled)
-	{
-		ReturnIconColor *= FLinearColor(1.0f, 1.0f, 1.0f, 0.3f); 
-	}
-	return ReturnIconColor;
-}
-
-FLinearColor SFlowGraphNode::GetNodeTitleTextColor() const
-{
-	FLinearColor ReturnTextColor = FLinearColor::White;
-	if (FlowGraphNode->GetSignalMode() != EFlowSignalMode::Enabled)
-	{
-		ReturnTextColor *= FLinearColor(1.0f, 1.0f, 1.0f, 0.3f); 
-	}
-	return ReturnTextColor;
-}
-
 TSharedPtr<SWidget> SFlowGraphNode::GetEnabledStateWidget() const
 {
 	if (FlowGraphNode->GetSignalMode() != EFlowSignalMode::Enabled && !GraphNode->IsAutomaticallyPlacedGhostNode())

--- a/Source/FlowEditor/Public/Graph/Widgets/SFlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Widgets/SFlowGraphNode.h
@@ -44,10 +44,6 @@ protected:
 	virtual const FSlateBrush* GetNodeBodyBrush() const override;
 
 	// purposely overriden non-virtual methods, avoiding engine modification
-	FSlateColor GetNodeTitleColor() const;
-	FSlateColor GetNodeBodyColor() const;
-	FSlateColor GetNodeTitleIconColor() const;
-	FLinearColor GetNodeTitleTextColor() const;
 	TSharedPtr<SWidget> GetEnabledStateWidget() const;
 
 	virtual void CreateStandardPinWidget(UEdGraphPin* Pin) override;


### PR DESCRIPTION
This changes gives you the same result as before. Benefit is we don't have to override the following methods. Basically less clutter.

**GetNodeTitleColor
GetNodeBodyColor
GetNodeTitleIconColor
GetNodeTitleTextColor**