### PR TITLE
Allow Sequence nodes to execute new connections

### DIFF
--- a/Source/Flow/Private/Nodes/Route/FlowNode_ExecutionSequence.cpp
+++ b/Source/Flow/Private/Nodes/Route/FlowNode_ExecutionSequence.cpp
@@ -16,10 +16,48 @@ UFlowNode_ExecutionSequence::UFlowNode_ExecutionSequence(const FObjectInitialize
 
 void UFlowNode_ExecutionSequence::ExecuteInput(const FName& PinName)
 {
+	if(bSavePinExecutionState)
+	{
+		ExecuteNewConnections();
+		return;
+	}
+	
 	for (const FFlowPin& Output : OutputPins)
 	{
 		TriggerOutput(Output.PinName, false);
 	}
 
 	Finish();
+}
+
+#if WITH_EDITOR
+FString UFlowNode_ExecutionSequence::GetNodeDescription() const
+{
+	if(bSavePinExecutionState)
+	{
+		return TEXT("Saves pin execution state");
+	}
+	
+	return Super::GetNodeDescription();
+}
+#endif
+
+void UFlowNode_ExecutionSequence::OnLoad_Implementation()
+{
+	ExecuteNewConnections();
+}
+
+void UFlowNode_ExecutionSequence::ExecuteNewConnections()
+{
+	for (const FFlowPin& Output : OutputPins)
+	{
+		const FConnectedPin& Connection = GetConnection(Output.PinName);
+		if(ExecutedConnections.Contains(Connection.NodeGuid))
+		{
+			continue;
+		}
+
+		TriggerOutput(Output.PinName, false);
+		ExecutedConnections.Emplace(Connection.NodeGuid);
+	}
 }

--- a/Source/Flow/Public/Nodes/Route/FlowNode_ExecutionSequence.h
+++ b/Source/Flow/Public/Nodes/Route/FlowNode_ExecutionSequence.h
@@ -15,8 +15,32 @@ class FLOW_API UFlowNode_ExecutionSequence final : public UFlowNode
 
 #if WITH_EDITOR
 	virtual bool CanUserAddOutput() const override { return true; }
+
+	virtual FString GetNodeDescription() const override;
 #endif
 
+	virtual void OnLoad_Implementation() override;
+	
 protected:
 	virtual void ExecuteInput(const FName& PinName) override;
+
+	/**
+	 * If enabled and the flowgraph is saved during gameplay, this node
+	 * tracks and saves which pins it has executed.
+	 *
+	 * If you add new connections or replace old connections with with
+	 * different nodes, this node will detect the changes. If during gameplay
+	 * you load an old save game which had different connections, this node
+	 * will automatically execute the updated connections you created.
+	 *
+	 * This is useful if you want the ability to add new parts to your
+	 * graph after release.
+	 */
+	UPROPERTY(EditAnywhere)
+	bool bSavePinExecutionState = false;
+	
+	UPROPERTY(SaveGame)
+	TSet<FGuid> ExecutedConnections;
+	
+	void ExecuteNewConnections();
 };


### PR DESCRIPTION
This is an update to the Sequence node, based on what we discussed shortly on Discord.

This adds a new flag to Sequence, which makes it track which connections it executed previously. If new connections are added or old ones are changed, it can then execute the changed connections when loading a save game.

Reasoning: This allows the developer to add new logic into existing flowgraphs, without causing issues in savegames. Without this feature, if a player has saved the game and new logic is added into a graph, there is no mechanism to ensure the logic is ran when the game is loaded. With this change, the developer can simply update the sequence connections and new nodes will execute after the game is loaded.

I don't know if this is the optimal/best way to go about it, but I figured I'll open this PR for any ideas/discussion since I had this code anyway.


# Example scenarios:

## Add a new connection:

- Developer creates a sequence and enables the save pin execution flag.
- Developer adds one connection to the node
- Player plays, the sequence is executed, player saves the game
- Developer adds a new connection to the sequence node
- Players load game, since the save flag was enabled, the newly added connection is executed, allowing the player to get the new features

## Replace a connection

Same as above, but instead of adding a new pin, the developer can replace an existing connection with a new node.
The code stores the FGuid of the connected node, so it can detect when the connected node changes.
