### PR TITLE
add bExactMatch option to Notify Actor flow node

### DIFF
--- a/Source/Flow/Private/Nodes/World/FlowNode_NotifyActor.cpp
+++ b/Source/Flow/Private/Nodes/World/FlowNode_NotifyActor.cpp
@@ -8,6 +8,7 @@
 
 UFlowNode_NotifyActor::UFlowNode_NotifyActor(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
+	, bExactMatch(true)
 	, NetMode(EFlowNetMode::Authority)
 {
 #if WITH_EDITOR
@@ -19,7 +20,7 @@ void UFlowNode_NotifyActor::ExecuteInput(const FName& PinName)
 {
 	if (const UFlowSubsystem* FlowSubsystem = GetWorld()->GetGameInstance()->GetSubsystem<UFlowSubsystem>())
 	{
-		for (const TWeakObjectPtr<UFlowComponent>& Component : FlowSubsystem->GetComponents<UFlowComponent>(IdentityTags, EGameplayContainerMatchType::Any))
+		for (const TWeakObjectPtr<UFlowComponent>& Component : FlowSubsystem->GetComponents<UFlowComponent>(IdentityTags, EGameplayContainerMatchType::Any, bExactMatch))
 		{
 			Component->NotifyFromGraph(NotifyTags, NetMode);
 		}

--- a/Source/Flow/Public/Nodes/World/FlowNode_NotifyActor.h
+++ b/Source/Flow/Public/Nodes/World/FlowNode_NotifyActor.h
@@ -18,6 +18,14 @@ class FLOW_API UFlowNode_NotifyActor : public UFlowNode
 protected:
 	UPROPERTY(EditAnywhere, Category = "Notify")
 	FGameplayTagContainer IdentityTags;
+
+	/**
+	 * If true, identity tags must be an exact match.
+	 * Be careful, setting this to false may be very expensive, as the
+	 * search cost is proportional to the number of registered Gameplay Tags!
+	 */
+	UPROPERTY(EditAnywhere, Category = "Notify")
+	bool bExactMatch;
 	
 	UPROPERTY(EditAnywhere, Category = "Notify")
 	FGameplayTagContainer NotifyTags;


### PR DESCRIPTION
Hello, this change adds a `bExactMatch` option to the Notify Actor node. `FlowSubsystem->GetComponents` already has that built in functionality, and adding this option allows out of the box broadcasting to components in a more versatile way, e.g. 'disable all interactions'. I realize the performance concern, and kept that note in the property description, but for non-open-world games this seems like a nice core built in feature so that designers don't have to add all exact identity tags to a flow component: e.g. `Object` and `Object.Interaction` and `Object.Interaction.Store`, just the last one.

Thanks!