### PR TITLE
Add custom color support to nodes

### DIFF
--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -39,6 +39,7 @@ UFlowNode::UFlowNode(const FObjectInitializer& ObjectInitializer)
 #if WITH_EDITOR
 	Category = TEXT("Uncategorized");
 	NodeStyle = EFlowNodeStyle::Default;
+	NodeColor = FLinearColor::Black;
 #endif
 
 	InputPins = {DefaultInputPin};
@@ -119,6 +120,17 @@ FText UFlowNode::GetNodeToolTip() const
 	}
 
 	return GetClass()->GetToolTipText();
+}
+
+bool UFlowNode::GetDynamicTitleColor(FLinearColor& OutColor) const
+{
+	if (NodeStyle == EFlowNodeStyle::Custom)
+	{
+		OutColor = NodeColor;
+		return true;
+	}
+
+	return false;
 }
 
 FString UFlowNode::GetNodeDescription() const

--- a/Source/Flow/Public/FlowTypes.h
+++ b/Source/Flow/Public/FlowTypes.h
@@ -14,7 +14,8 @@ enum class EFlowNodeStyle : uint8
 	InOut UMETA(Hidden),
 	Latent,
 	Logic,
-	SubGraph UMETA(Hidden)
+	SubGraph UMETA(Hidden),
+	Custom
 };
 #endif
 

--- a/Source/Flow/Public/Nodes/FlowNode.h
+++ b/Source/Flow/Public/Nodes/FlowNode.h
@@ -53,6 +53,10 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category = "FlowNode")
 	EFlowNodeStyle NodeStyle;
 
+	// Set Node Style to custom to use your own color for this node
+	UPROPERTY(EditDefaultsOnly, Category = "FlowNode", meta = (EditCondition = "NodeStyle == EFlowNodeStyle::Custom"))
+	FLinearColor NodeColor;
+
 	uint8 bCanDelete : 1;
 	uint8 bCanDuplicate : 1;
 
@@ -93,7 +97,7 @@ public:
 	virtual FText GetNodeToolTip() const;
 	
 	// This method allows to have different for every node instance, i.e. Red if node represents enemy, Green if node represents a friend
-	virtual bool GetDynamicTitleColor(FLinearColor& OutColor) const { return false; }
+	virtual bool GetDynamicTitleColor(FLinearColor& OutColor) const;
 
 	EFlowNodeStyle GetNodeStyle() const { return NodeStyle; }
 


### PR DESCRIPTION
Setting Node Style to custom will let the user colorize the node to his/her own color. 

NOTE: This is prioritized over **UFlowGraphSettings->NodeSpecificColors** and **UFlowGraphSettings->NodeTitleColors** which means if you set to Custom then _NodeSpecificColors_ and _NodeTitleColors_ are ignored for that node.

![NodeColor](https://user-images.githubusercontent.com/5410301/218445715-ebb0f80d-6b62-4775-8b99-47a42d4fd4c4.gif)