### PR TITLE
✨ Added support for Flow variables.

### DIFF
--- a/Flow.uplugin
+++ b/Flow.uplugin
@@ -34,6 +34,10 @@
 		{
 			"Name": "EditorScriptingUtilities",
 			"Enabled": true
+		},
+		{
+			"Name": "StructUtils",
+			"Enabled": true
 		}
 	]
 }

--- a/Source/Flow/Flow.Build.cs
+++ b/Source/Flow/Flow.Build.cs
@@ -10,7 +10,8 @@ public class Flow : ModuleRules
 
 		PublicDependencyModuleNames.AddRange(new[]
 		{
-			"LevelSequence"
+			"LevelSequence",
+			"StructUtils"
 		});
 
 		PrivateDependencyModuleNames.AddRange(new[]
@@ -31,7 +32,8 @@ public class Flow : ModuleRules
 			PublicDependencyModuleNames.AddRange(new[]
 			{
 				"MessageLog",
-				"UnrealEd"
+				"UnrealEd",
+				"BlueprintGraph"
 			});
 		}
 	}

--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -144,7 +144,12 @@ void UFlowAsset::HarvestNodeConnections()
 				if (const UEdGraphPin* LinkedPin = ThisPin->LinkedTo[0])
 				{
 					const UEdGraphNode* LinkedNode = LinkedPin->GetOwningNode();
-					FoundConnections.Add(ThisPin->PinName, FConnectedPin(LinkedNode->NodeGuid, LinkedPin->PinName));
+					FFlowInputOutputPin VariablePin;
+					if (ThisPin->PinType.PinCategory != UEdGraphSchema_K2::PC_Exec)
+					{
+						VariablePin = FFlowInputOutputPin(LinkedPin->PinName, ThisPin->PinName, LinkedNode->NodeGuid, Node->NodeGuid);
+					}
+					FoundConnections.Add(ThisPin->PinName, FConnectedPin(LinkedNode->NodeGuid, LinkedPin->PinName, VariablePin));
 				}
 			}
 		}
@@ -436,9 +441,9 @@ void UFlowAsset::TriggerCustomOutput(const FName& EventName) const
 	NodeOwningThisAssetInstance->TriggerOutput(EventName);
 }
 
-void UFlowAsset::TriggerInput(const FGuid& NodeGuid, const FName& PinName)
+void UFlowAsset::TriggerInput(const FConnectedPin& InConnectedPin)
 {
-	if (UFlowNode* Node = Nodes.FindRef(NodeGuid))
+	if (UFlowNode* Node = Nodes.FindRef(InConnectedPin.NodeGuid))
 	{
 		if (!ActiveNodes.Contains(Node))
 		{
@@ -446,7 +451,7 @@ void UFlowAsset::TriggerInput(const FGuid& NodeGuid, const FName& PinName)
 			RecordedNodes.Add(Node);
 		}
 
-		Node->TriggerInput(PinName);
+		Node->TriggerInput(InConnectedPin);
 	}
 }
 

--- a/Source/Flow/Private/FlowSubsystemVariables.cpp
+++ b/Source/Flow/Private/FlowSubsystemVariables.cpp
@@ -1,0 +1,298 @@
+﻿// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#include "FlowSubsystemVariables.h"
+
+#define GET_BAG_VALUE(Type) if (MemberName == NAME_None) \
+{ \
+	return false; \
+} \
+const auto Bag = PropertyReference.RuntimeBag.IsValid() ? PropertyReference.RuntimeBag : PropertyReference.Properties; \
+const auto Result = Bag.GetValue##Type(MemberName); \
+if (Result.IsValid()) \
+{ \
+	OutValue = Result.GetValue(); \
+	return true; \
+} \
+return false
+
+#define GET_STRUCT_VALUE(Type) if (MemberName == NAME_None) \
+{ \
+	return false; \
+} \
+const auto Bag = PropertyReference.RuntimeBag.IsValid() ? PropertyReference.RuntimeBag : PropertyReference.Properties; \
+const auto Result = Bag.GetValueStruct<Type>(MemberName); \
+if (Result.IsValid()) \
+{ \
+	OutValue = *Result.GetValue(); \
+	return true; \
+} \
+return false
+
+#define SET_FLOW_VALUE(Type) if (MemberName == NAME_None) \
+{ \
+	return EFlowVariableSetResult::MemberNameNone; \
+} \
+auto& Bag = Property.RuntimeBag; \
+if (Bag.FindPropertyDescByName(MemberName) == nullptr) \
+{ \
+	Bag.AddProperty(MemberName, EPropertyBagPropertyType::Type); \
+} \
+auto Result = Bag.SetValue##Type(MemberName, Value); \
+switch (Result) \
+{ \
+	case EPropertyBagResult::TypeMismatch: \
+		return EFlowVariableSetResult::TypeMismatch; \
+	case EPropertyBagResult::OutOfBounds: \
+		return EFlowVariableSetResult::OutOfBounds; \
+	case EPropertyBagResult::PropertyNotFound: \
+		return EFlowVariableSetResult::PropertyNotFound; \
+	default: ; \
+} \
+return EFlowVariableSetResult::Success
+
+#define SET_STRUCT_VALUE(Type) if (MemberName == NAME_None) \
+{ \
+return EFlowVariableSetResult::MemberNameNone; \
+} \
+auto& Bag = Property.RuntimeBag; \
+if (Bag.FindPropertyDescByName(MemberName) == nullptr) \
+{ \
+Bag.AddProperty(MemberName, EPropertyBagPropertyType::Struct, TBaseStructure<Type>::Get()); \
+} \
+auto Result = Bag.SetValueStruct(MemberName, Value); \
+switch (Result) \
+{ \
+case EPropertyBagResult::TypeMismatch: \
+return EFlowVariableSetResult::TypeMismatch; \
+case EPropertyBagResult::OutOfBounds: \
+return EFlowVariableSetResult::OutOfBounds; \
+case EPropertyBagResult::PropertyNotFound: \
+return EFlowVariableSetResult::PropertyNotFound; \
+default: ; \
+} \
+return EFlowVariableSetResult::Success
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetBoolVariable(FFlowPropertyBag& Property, const FName MemberName, const bool Value)
+{
+	SET_FLOW_VALUE(Bool);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetByteVariable(FFlowPropertyBag& Property, const FName MemberName, const uint8 Value)
+{
+	SET_FLOW_VALUE(Byte);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetInt32Variable(FFlowPropertyBag& Property, const FName MemberName, const int32 Value)
+{
+	SET_FLOW_VALUE(Int32);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetInt64Variable(FFlowPropertyBag& Property, const FName MemberName, const int64 Value)
+{
+	SET_FLOW_VALUE(Int64);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetFloatVariable(FFlowPropertyBag& Property, const FName MemberName, const float Value)
+{
+	SET_FLOW_VALUE(Float);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetDoubleVariable(FFlowPropertyBag& Property, const FName MemberName, const double Value)
+{
+	SET_FLOW_VALUE(Double);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetNameVariable(FFlowPropertyBag& Property, const FName MemberName, const FName Value)
+{
+	SET_FLOW_VALUE(Name);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetStringVariable(FFlowPropertyBag& Property, const FName MemberName, const FString Value)
+{
+	SET_FLOW_VALUE(String);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetTextVariable(FFlowPropertyBag& Property, const FName MemberName, const FText Value)
+{
+	SET_FLOW_VALUE(Text);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetObjectVariable(FFlowPropertyBag& Property, const FName MemberName, UObject* Value)
+{
+	SET_FLOW_VALUE(Object);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetClassVariable(FFlowPropertyBag& Property, const FName MemberName, UClass* Value)
+{
+	SET_FLOW_VALUE(Class);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetVectorVariable(FFlowPropertyBag& Property, const FName MemberName, const FVector Value)
+{
+	SET_STRUCT_VALUE(FVector);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetVector2DVariable(FFlowPropertyBag& Property, const FName MemberName, const FVector2D Value)
+{
+	SET_STRUCT_VALUE(FRotator);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetVector4Variable(FFlowPropertyBag& Property, const FName MemberName, const FVector4 Value)
+{
+	SET_STRUCT_VALUE(FVector4);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetIntVectorVariable(FFlowPropertyBag& Property, const FName MemberName, const FIntVector Value)
+{
+	SET_STRUCT_VALUE(FIntVector);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetIntVector2DVariable(FFlowPropertyBag& Property, const FName MemberName, const FIntPoint Value)
+{
+	SET_STRUCT_VALUE(FIntPoint);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetRotatorVariable(FFlowPropertyBag& Property, const FName MemberName, const FRotator Value)
+{
+	SET_STRUCT_VALUE(FRotator);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetTransformVariable(FFlowPropertyBag& Property, const FName MemberName, const FTransform Value)
+{
+	SET_STRUCT_VALUE(FTransform);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetGameplayTagVariable(FFlowPropertyBag& Property, const FName MemberName, const FGameplayTag Value)
+{
+	SET_STRUCT_VALUE(FGameplayTag);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetGameplayTagContainerVariable(FFlowPropertyBag& Property, const FName MemberName, const FGameplayTagContainer Value)
+{
+	SET_STRUCT_VALUE(FGameplayTagContainer);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetDateTimeVariable(FFlowPropertyBag& Property, const FName MemberName, const FDateTime Value)
+{
+	SET_STRUCT_VALUE(FDateTime);
+}
+
+EFlowVariableSetResult UFlowSubsystemVariables::SetQuatVariable(FFlowPropertyBag& Property, const FName MemberName, const FQuat Value)
+{
+	SET_STRUCT_VALUE(FQuat);
+}
+
+bool UFlowSubsystemVariables::GetVariableBool(const FFlowPropertyBag& PropertyReference, const FName MemberName, bool& OutValue)
+{
+	GET_BAG_VALUE(Bool);
+}
+
+bool UFlowSubsystemVariables::GetVariableByte(const FFlowPropertyBag& PropertyReference, const FName MemberName, uint8& OutValue)
+{
+	GET_BAG_VALUE(Byte);
+}
+
+bool UFlowSubsystemVariables::GetVariableInteger(const FFlowPropertyBag& PropertyReference, const FName MemberName, int32& OutValue)
+{
+	GET_BAG_VALUE(Int32);
+}
+
+bool UFlowSubsystemVariables::GetVariableInteger64(const FFlowPropertyBag& PropertyReference, const FName MemberName,int64& OutValue)
+{
+	GET_BAG_VALUE(Int64);
+}
+
+bool UFlowSubsystemVariables::GetVariableFloat(const FFlowPropertyBag& PropertyReference, const FName MemberName, float& OutValue)
+{
+	GET_BAG_VALUE(Float);
+}
+
+bool UFlowSubsystemVariables::GetVariableDouble(const FFlowPropertyBag& PropertyReference, const FName MemberName, double& OutValue)
+{
+	GET_BAG_VALUE(Double);
+}
+
+bool UFlowSubsystemVariables::GetVariableName(const FFlowPropertyBag& PropertyReference, const FName MemberName, FName& OutValue)
+{
+	GET_BAG_VALUE(Name);
+}
+
+bool UFlowSubsystemVariables::GetVariableString(const FFlowPropertyBag& PropertyReference, const FName MemberName, FString& OutValue)
+{
+	GET_BAG_VALUE(String);
+}
+
+bool UFlowSubsystemVariables::GetVariableText(const FFlowPropertyBag& PropertyReference, const FName MemberName, FText& OutValue)
+{
+	GET_BAG_VALUE(Text);
+}
+
+bool UFlowSubsystemVariables::GetVariableObject(const FFlowPropertyBag& PropertyReference, const FName MemberName, UObject*& OutValue)
+{
+	GET_BAG_VALUE(Object);
+}
+
+bool UFlowSubsystemVariables::GetVariableClass(const FFlowPropertyBag& PropertyReference, const FName MemberName, UClass*& OutValue)
+{
+	GET_BAG_VALUE(Class);
+}
+
+bool UFlowSubsystemVariables::GetVariableVector(const FFlowPropertyBag& PropertyReference, const FName MemberName, FVector& OutValue)
+{
+	GET_STRUCT_VALUE(FVector);
+}
+
+bool UFlowSubsystemVariables::GetVariableVector2D(const FFlowPropertyBag& PropertyReference, const FName MemberName, FVector2D& OutValue)
+{
+	GET_STRUCT_VALUE(FVector2D);
+}
+
+bool UFlowSubsystemVariables::GetVariableVector4(const FFlowPropertyBag& PropertyReference, const FName MemberName, FVector4& OutValue)
+{
+	GET_STRUCT_VALUE(FVector4);
+}
+
+bool UFlowSubsystemVariables::GetVariableIntVector(const FFlowPropertyBag& PropertyReference, const FName MemberName, FIntVector& OutValue)
+{
+	GET_STRUCT_VALUE(FIntVector);
+}
+
+bool UFlowSubsystemVariables::GetVariableIntVector2(const FFlowPropertyBag& PropertyReference, const FName MemberName, FIntPoint& OutValue)
+{
+	GET_STRUCT_VALUE(FIntPoint);
+}
+
+bool UFlowSubsystemVariables::GetVariableRotator(const FFlowPropertyBag& PropertyReference, const FName MemberName, FRotator& OutValue)
+{
+	GET_STRUCT_VALUE(FRotator);
+}
+
+bool UFlowSubsystemVariables::GetVariableTransform(const FFlowPropertyBag& PropertyReference, const FName MemberName, FTransform& OutValue)
+{
+	GET_STRUCT_VALUE(FTransform);
+}
+
+bool UFlowSubsystemVariables::GetVariableGameplayTag(const FFlowPropertyBag& PropertyReference, const FName MemberName, FGameplayTag& OutValue)
+{
+	GET_STRUCT_VALUE(FGameplayTag);
+}
+
+bool UFlowSubsystemVariables::GetVariableGameplayTagContainer(const FFlowPropertyBag& PropertyReference, const FName MemberName, FGameplayTagContainer& OutValue)
+{
+	GET_STRUCT_VALUE(FGameplayTagContainer);
+}
+
+bool UFlowSubsystemVariables::GetVariableDateTime(const FFlowPropertyBag& PropertyReference, const FName MemberName, FDateTime& OutValue)
+{
+	GET_STRUCT_VALUE(FDateTime);
+}
+
+bool UFlowSubsystemVariables::GetVariableQuat(const FFlowPropertyBag& PropertyReference, const FName MemberName, FQuat& OutValue)
+{
+	GET_STRUCT_VALUE(FQuat);
+}
+
+#undef GET_BAG_VALUE
+#undef GET_STRUCT_VALUE
+#undef SET_FLOW_VALUE
+#undef SET_STRUCT_VALUE

--- a/Source/Flow/Private/Nodes/FlowVariable.cpp
+++ b/Source/Flow/Private/Nodes/FlowVariable.cpp
@@ -1,0 +1,43 @@
+// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#include "Nodes/FlowVariable.h"
+#include "Nodes/FlowNode.h"
+
+FFlowPropertyBag::FFlowPropertyBag(const FProperty& Property)
+	: PropertyName(Property.GetFName())
+	, PinTooltip(Property.GetToolTipText(true).ToString())
+{
+	Properties.AddProperty(PropertyName, &Property);
+}
+
+FFlowInputOutputPin::FFlowInputOutputPin(const FName& InputPinName, const FName& OutputPinName, const FGuid& InputNodeGuid, const FGuid& OutputNodeGuid)
+	: InputPinName(InputPinName)
+	, OutputPinName(OutputPinName)
+	, InputNodeGuid(InputNodeGuid)
+	, OutputNodeGuid(OutputNodeGuid)
+{
+}
+
+bool FFlowInputOutputPin::IsPinValid() const
+{
+	return !InputPinName.IsNone() || !OutputPinName.IsNone();
+}
+
+void FFlowInputOutputPin::SetInputValue(const UFlowNode* FromOutputNode, const FProperty* InProperty, const FProperty* OutProperty)
+{
+	check(InProperty);
+	check(OutProperty);
+
+	const FName PropName = InProperty->GetFName();
+
+	if (PropertyBag.FindPropertyDescByName(PropName) == nullptr)
+	{
+		PropertyBag.AddProperty(PropName, EPropertyBagPropertyType::Struct, FFlowPropertyBag::StaticStruct());
+	}
+
+	const auto StructProperty = CastField<FStructProperty>(OutProperty);
+	check(StructProperty);
+	const auto FlowBag = *StructProperty->ContainerPtrToValuePtr<FFlowPropertyBag>(FromOutputNode);
+	
+	PropertyBag.SetValueStruct(PropName, FlowBag);
+}

--- a/Source/Flow/Private/Nodes/Variables/FlowNodeVariable.cpp
+++ b/Source/Flow/Private/Nodes/Variables/FlowNodeVariable.cpp
@@ -1,0 +1,11 @@
+﻿// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#include "Nodes/Variables/FlowNodeVariable.h"
+
+UFlowNodeVariable::UFlowNodeVariable()
+{
+#if WITH_EDITOR
+	Category = TEXT("Variables");
+	NodeStyle = EFlowNodeStyle::Default;
+#endif
+}

--- a/Source/Flow/Private/Nodes/Variables/FlowNode_CreateProperty.cpp
+++ b/Source/Flow/Private/Nodes/Variables/FlowNode_CreateProperty.cpp
@@ -1,0 +1,16 @@
+﻿// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#include "Nodes/Variables/FlowNode_CreateProperty.h"
+
+UFlowNode_CreateProperty::UFlowNode_CreateProperty()
+{
+#if WITH_EDITOR
+	Category = TEXT("Variables");
+	NodeStyle = EFlowNodeStyle::Default;
+#endif
+}
+
+void UFlowNode_CreateProperty::ExecuteInput(const FName& PinName)
+{
+	TriggerFirstOutput(true);
+}

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -5,6 +5,7 @@
 #include "FlowMessageLog.h"
 #include "FlowSave.h"
 #include "FlowTypes.h"
+#include "Nodes/FlowPin.h"
 #include "FlowAsset.generated.h"
 
 class UFlowNode;
@@ -261,7 +262,7 @@ private:
 	void TriggerCustomEvent(UFlowNode_SubGraph* Node, const FName& EventName) const;
 	void TriggerCustomOutput(const FName& EventName) const;
 
-	void TriggerInput(const FGuid& NodeGuid, const FName& PinName);
+	void TriggerInput(const FConnectedPin& InConnectedPin);
 
 	void FinishNode(UFlowNode* Node);
 	void ResetNodes();

--- a/Source/Flow/Public/FlowSubsystemVariables.h
+++ b/Source/Flow/Public/FlowSubsystemVariables.h
@@ -1,0 +1,165 @@
+﻿// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#pragma once
+
+#include "GameplayTagContainer.h"
+#include "Nodes/FlowVariable.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "FlowSubsystemVariables.generated.h"
+
+UENUM(BlueprintType)
+enum class EFlowVariableSetResult : uint8
+{
+	Success,			// Operation succeeded.
+	TypeMismatch,		// Tried to access mismatching type (e.g. setting a struct to bool)
+	OutOfBounds,		// Tried to access an array property out of bounds.
+	PropertyNotFound,	// Could not find property of specified name.
+	MemberNameNone		// Member name was none.
+};
+
+/**
+ * Flow Subsystem Variables
+ * - manages variables for Flow Graphs
+ */
+UCLASS()
+class FLOW_API UFlowSubsystemVariables : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+
+//////////////////////////////////////////////////////////////////////////
+// Variables
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Bool"))
+	EFlowVariableSetResult SetBoolVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const bool Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Byte"))
+	EFlowVariableSetResult SetByteVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const uint8 Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Int32"))
+	EFlowVariableSetResult SetInt32Variable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const int32 Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Int64"))
+	EFlowVariableSetResult SetInt64Variable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const int64 Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Float"))
+	EFlowVariableSetResult SetFloatVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const float Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Double"))
+	EFlowVariableSetResult SetDoubleVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const double Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Name"))
+	EFlowVariableSetResult SetNameVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FName Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set String"))
+	EFlowVariableSetResult SetStringVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FString Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Text"))
+	EFlowVariableSetResult SetTextVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FText Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Object"))
+	EFlowVariableSetResult SetObjectVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, UObject* Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Class"))
+	EFlowVariableSetResult SetClassVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, UClass* Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Vector"))
+	EFlowVariableSetResult SetVectorVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FVector Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Vector (2D)"))
+	EFlowVariableSetResult SetVector2DVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FVector2D Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Vector4"))
+	EFlowVariableSetResult SetVector4Variable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FVector4 Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Int Vector"))
+	EFlowVariableSetResult SetIntVectorVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FIntVector Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Int Vector (2D)"))
+	EFlowVariableSetResult SetIntVector2DVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FIntPoint Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Rotator"))
+	EFlowVariableSetResult SetRotatorVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FRotator Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Transform"))
+	EFlowVariableSetResult SetTransformVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FTransform Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set GameplayTag"))
+	EFlowVariableSetResult SetGameplayTagVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FGameplayTag Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set GameplayTag Container"))
+	EFlowVariableSetResult SetGameplayTagContainerVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FGameplayTagContainer Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Date Time"))
+	EFlowVariableSetResult SetDateTimeVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FDateTime Value);
+
+	UFUNCTION(BlueprintCallable, Category = FlowSubsystemVariables, meta = (DisplayName = "Set Quat"))
+	EFlowVariableSetResult SetQuatVariable(UPARAM(ref) FFlowPropertyBag& Property, const FName MemberName, const FQuat Value);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Bool"))
+	bool GetVariableBool(const FFlowPropertyBag& PropertyReference, const FName MemberName, bool& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Byte"))
+	bool GetVariableByte(const FFlowPropertyBag& PropertyReference, const FName MemberName, uint8& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Int32"))
+	bool GetVariableInteger(const FFlowPropertyBag& PropertyReference, const FName MemberName, int32& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Int64"))
+	bool GetVariableInteger64(const FFlowPropertyBag& PropertyReference, const FName MemberName, int64& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Float"))
+	bool GetVariableFloat(const FFlowPropertyBag& PropertyReference, const FName MemberName, float& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Double"))
+	bool GetVariableDouble(const FFlowPropertyBag& PropertyReference, const FName MemberName, double& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Name"))
+	bool GetVariableName(const FFlowPropertyBag& PropertyReference, const FName MemberName, FName& OutValue);
+	
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get String"))
+	bool GetVariableString(const FFlowPropertyBag& PropertyReference, const FName MemberName, FString& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Text"))
+	bool GetVariableText(const FFlowPropertyBag& PropertyReference, const FName MemberName, FText& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Object"))
+	bool GetVariableObject(const FFlowPropertyBag& PropertyReference, const FName MemberName, UObject*& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Class"))
+	bool GetVariableClass(const FFlowPropertyBag& PropertyReference, const FName MemberName, UClass*& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Vector"))
+	bool GetVariableVector(const FFlowPropertyBag& PropertyReference, const FName MemberName, FVector& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Vector (2D)"))
+	bool GetVariableVector2D(const FFlowPropertyBag& PropertyReference, const FName MemberName, FVector2D& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Vector4"))
+	bool GetVariableVector4(const FFlowPropertyBag& PropertyReference, const FName MemberName, FVector4& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Int Vector"))
+	bool GetVariableIntVector(const FFlowPropertyBag& PropertyReference, const FName MemberName, FIntVector& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Int Vector (2D)"))
+	bool GetVariableIntVector2(const FFlowPropertyBag& PropertyReference, const FName MemberName, FIntPoint& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Rotator"))
+	bool GetVariableRotator(const FFlowPropertyBag& PropertyReference, const FName MemberName, FRotator& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Transform"))
+	bool GetVariableTransform(const FFlowPropertyBag& PropertyReference, const FName MemberName, FTransform& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get GameplayTag"))
+	bool GetVariableGameplayTag(const FFlowPropertyBag& PropertyReference, const FName MemberName, FGameplayTag& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get GameplayTag Container"))
+	bool GetVariableGameplayTagContainer(const FFlowPropertyBag& PropertyReference, const FName MemberName, FGameplayTagContainer& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Date Time"))
+	bool GetVariableDateTime(const FFlowPropertyBag& PropertyReference, const FName MemberName, FDateTime& OutValue);
+
+	UFUNCTION(BlueprintPure, Category = FlowSubsystemVariables, meta = (DisplayName = "Get Quat"))
+	bool GetVariableQuat(const FFlowPropertyBag& PropertyReference, const FName MemberName, FQuat& OutValue);
+};

--- a/Source/Flow/Public/Nodes/FlowNode.h
+++ b/Source/Flow/Public/Nodes/FlowNode.h
@@ -280,7 +280,7 @@ protected:
 	void K2_OnActivate();
 	
 	// Trigger execution of input pin
-	void TriggerInput(const FName& PinName, const EFlowPinActivationType ActivationType = EFlowPinActivationType::Default);
+	void TriggerInput(const FConnectedPin& ConnectedPin, const EFlowPinActivationType ActivationType = EFlowPinActivationType::Default);
 
 	// Method reacting on triggering Input pin
 	virtual void ExecuteInput(const FName& PinName);
@@ -407,4 +407,8 @@ protected:
 
 	UFUNCTION(BlueprintNativeEvent, Category = "FlowNode")
 	void OnPassThrough();
+
+public:
+
+	FORCEINLINE bool IsSignalModeEnabled() const { return SignalMode == EFlowSignalMode::Enabled; }
 };

--- a/Source/Flow/Public/Nodes/FlowPin.h
+++ b/Source/Flow/Public/Nodes/FlowPin.h
@@ -1,6 +1,7 @@
 // Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
 
 #pragma once
+#include "FlowVariable.h"
 
 #include "FlowPin.generated.h"
 
@@ -154,9 +155,17 @@ struct FLOW_API FConnectedPin
 	UPROPERTY()
 	FName PinName;
 
+	UPROPERTY()
+	FFlowInputOutputPin VariablePin;
+
 	FConnectedPin()
 		: NodeGuid(FGuid())
 		, PinName(NAME_None)
+	{
+	}
+
+	// @TODO This is a temporary fix to prevent compile error from UFlowGraphNode::ForcePinActivation 
+	FConnectedPin(const FName& PinName) : PinName(PinName)
 	{
 	}
 
@@ -165,6 +174,15 @@ struct FLOW_API FConnectedPin
 		, PinName(InPinName)
 	{
 	}
+
+	FConnectedPin(const FGuid NodeGuid, const FName& PinName, const FFlowInputOutputPin& VariablePin)
+		: NodeGuid(NodeGuid)
+		, PinName(PinName)
+		, VariablePin(VariablePin)
+	{
+	}
+
+	FORCEINLINE bool IsValidPin() const { return PinName != NAME_None && NodeGuid.IsValid(); }
 
 	FORCEINLINE bool operator==(const FConnectedPin& Other) const
 	{

--- a/Source/Flow/Public/Nodes/FlowPropertyHelpers.h
+++ b/Source/Flow/Public/Nodes/FlowPropertyHelpers.h
@@ -1,0 +1,167 @@
+// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#pragma once
+
+#include "FlowVariable.h"
+
+#define IS_FLOW_STRUCT_PROPERTY(Property)	const FStructProperty* StructProperty = CastField<FStructProperty>(Property); \
+if (StructProperty && StructProperty->Struct == TBaseStructure<FFlowPropertyBag>::Get())
+
+namespace FlowPropertyHelpers
+{
+	/**
+	* public
+	* static FlowPropertyHelpers::IsPropertyExposedAsInput
+	* Checks if the given property is exposed as input.
+	* @param Property [const FProperty*] Property to check.
+	**/
+	static FORCEINLINE_DEBUGGABLE bool IsPropertyExposedAsInput(const FProperty* Property)
+	{
+		IS_FLOW_STRUCT_PROPERTY(Property)
+		{
+			return !Property->HasAnyPropertyFlags(CPF_DisableEditOnInstance | CPF_BlueprintReadOnly) && Property->HasAllPropertyFlags(CPF_ExposeOnSpawn);
+		}
+
+		return false;
+	}
+
+	/**
+	* public
+	* static FlowPropertyHelpers::IsPropertyExposedAsOutput
+	* Checks if the given property is exposed as output.
+	* @param Property [const FProperty*] Property to check.
+	**/
+	static FORCEINLINE_DEBUGGABLE bool IsPropertyExposedAsOutput(const FProperty* Property)
+	{
+		IS_FLOW_STRUCT_PROPERTY(Property)
+		{
+			return !Property->HasAnyPropertyFlags(CPF_DisableEditOnInstance) && Property->HasAnyPropertyFlags(CPF_BlueprintReadOnly | CPF_BlueprintVisible);
+		}
+
+		return false;
+	}
+
+	static FORCEINLINE_DEBUGGABLE FProperty* FindInputPropertyByPinName(const UFlowNode* TargetNode, const FName& InPinName)
+	{
+		if (!IsValid(TargetNode) || InPinName.IsNone())
+		{
+			return nullptr;
+		}
+
+		for (TFieldIterator<FProperty> PropIt(TargetNode->GetClass()); PropIt; ++PropIt)
+		{
+			FProperty* Property = *PropIt;
+			if (FlowPropertyHelpers::IsPropertyExposedAsInput(Property))
+			{
+				return Property;
+			}
+		}
+
+		return nullptr;
+	}
+
+	static FORCEINLINE_DEBUGGABLE FProperty* FindOutputPropertyByPinName(const UFlowNode* TargetNode, const FName& InPinName)
+	{
+		if (!IsValid(TargetNode) || InPinName.IsNone())
+		{
+			return nullptr;
+		}
+		
+		for (TFieldIterator<FProperty> PropIt(TargetNode->GetClass()); PropIt; ++PropIt)
+		{
+			FProperty* Property = *PropIt;
+			if (FlowPropertyHelpers::IsPropertyExposedAsOutput(Property))
+			{
+				return Property;
+			}
+		}
+
+		return nullptr;
+	}
+
+	static FORCEINLINE_DEBUGGABLE FFlowPropertyBag GetInputFlowPropertyBag(const UFlowNode* TargetNode)
+	{
+		if (IsValid(TargetNode))
+		{
+			for (TFieldIterator<FProperty> PropertyIterator(TargetNode->GetClass()); PropertyIterator; ++PropertyIterator)
+			{
+				const FProperty* Property = *PropertyIterator;
+				if (IsPropertyExposedAsInput(Property))
+				{
+					return FFlowPropertyBag(*Property);
+				}
+			}
+		}
+
+		return FFlowPropertyBag();
+	}
+
+	static FORCEINLINE_DEBUGGABLE FFlowPropertyBag GetOutputFlowPropertyBag(const UFlowNode* TargetNode)
+	{
+		for (TFieldIterator<FProperty> PropertyIterator(TargetNode->GetClass()); PropertyIterator; ++PropertyIterator)
+		{
+			const FProperty* Property = *PropertyIterator;
+			if (IsPropertyExposedAsOutput(Property))
+			{
+				return FFlowPropertyBag(*Property);
+			}
+		}
+
+		return FFlowPropertyBag();
+	}
+	
+	static FORCEINLINE_DEBUGGABLE bool SetPropertyValue(UFlowNode* TargetNode, const FConnectedPin& ConnectedPin)
+	{
+		if (!ConnectedPin.VariablePin.IsPinValid())
+		{
+			return false;
+		}
+		
+		for (TFieldIterator<FStructProperty> PropertyIterator(TargetNode->GetClass()); PropertyIterator; ++PropertyIterator)
+		{
+			const FStructProperty* StructProperty = *PropertyIterator;
+			if (FlowPropertyHelpers::IsPropertyExposedAsInput(StructProperty))
+			{
+				const auto& VariablePin = ConnectedPin.VariablePin;
+				const auto ValueStruct = VariablePin.PropertyBag.GetValueStruct<FFlowPropertyBag>(ConnectedPin.VariablePin.InputPinName);
+				check(ValueStruct.IsValid());
+				const auto ValuePtr = ValueStruct.GetValue();
+
+				auto NodeBag = StructProperty->ContainerPtrToValuePtr<FFlowPropertyBag>(TargetNode);
+				NodeBag->PropertyName = VariablePin.InputPinName;
+				NodeBag->RuntimeBag = ValuePtr->RuntimeBag.IsValid() ? ValuePtr->RuntimeBag : ValuePtr->Properties;
+				
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	static FORCEINLINE_DEBUGGABLE void SetVariablePin(const UFlowNode* TargetNode, FConnectedPin& TargetPin)
+	{
+		if (!TargetNode->IsSignalModeEnabled())
+		{
+			return;
+		}
+		
+		const FFlowPropertyBag OutputPropertyPin = FlowPropertyHelpers::GetOutputFlowPropertyBag(TargetNode);
+		if (OutputPropertyPin.IsValid())
+		{
+			const FConnectedPin FlowOutputPin = TargetNode->GetConnection(OutputPropertyPin.PropertyName);
+			if (FlowOutputPin.IsValidPin())
+			{
+				FFlowInputOutputPin InputPin;
+				const UFlowNode* LinkedNode = TargetNode->GetFlowAsset()->GetNode(FlowOutputPin.VariablePin.InputNodeGuid);
+				const UFlowNode* OutputNode = TargetNode->GetFlowAsset()->GetNode(FlowOutputPin.VariablePin.OutputNodeGuid);
+				const auto InputProperty = FlowPropertyHelpers::FindInputPropertyByPinName(LinkedNode, FlowOutputPin.VariablePin.InputPinName);
+				const auto OutputProperty = FlowPropertyHelpers::FindOutputPropertyByPinName(OutputNode, FlowOutputPin.VariablePin.OutputPinName);
+				InputPin = FlowOutputPin.VariablePin;
+				InputPin.SetInputValue(OutputNode, InputProperty, OutputProperty);
+				TargetPin.VariablePin = InputPin;
+			}
+		}
+	}
+}
+
+#undef IS_FLOW_STRUCT_PROPERTY

--- a/Source/Flow/Public/Nodes/FlowVariable.h
+++ b/Source/Flow/Public/Nodes/FlowVariable.h
@@ -1,0 +1,61 @@
+// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#pragma once
+
+#include "StructUtils/Public/PropertyBag.h"
+#include "FlowVariable.generated.h"
+
+class UFlowNode;
+
+USTRUCT(BlueprintType)
+struct FLOW_API FFlowPropertyBag
+{
+	GENERATED_BODY()
+	
+	UPROPERTY(EditAnywhere, Category = FlowProperty)
+	FInstancedPropertyBag Properties;
+
+	UPROPERTY(Transient)
+	FInstancedPropertyBag RuntimeBag;
+
+	UPROPERTY()
+	FName PropertyName;
+
+	UPROPERTY()
+	FString PinTooltip;
+
+	FORCEINLINE bool IsValid() const { return !PropertyName.IsNone(); }
+
+	FFlowPropertyBag() = default;
+	FFlowPropertyBag(const FProperty& Property);
+};
+
+USTRUCT()
+struct FLOW_API FFlowInputOutputPin
+{
+	GENERATED_BODY()
+
+	UPROPERTY(Transient)
+	FInstancedPropertyBag PropertyBag;
+
+	UPROPERTY()
+	FName InputPinName;
+
+	UPROPERTY()
+	FName OutputPinName;
+
+	UPROPERTY()
+	FGuid InputNodeGuid;
+
+	UPROPERTY()
+	FGuid OutputNodeGuid;
+
+	UPROPERTY()
+	FString PinTooltip;
+
+	FFlowInputOutputPin() = default;
+	FFlowInputOutputPin(const FName& InputPinName, const FName& OutputPinName, const FGuid& InputNodeGuid, const FGuid& OutputNodeGuid);
+
+	bool IsPinValid() const;
+	void SetInputValue(const UFlowNode* FromOutputNode, const FProperty* InProperty, const FProperty* OutProperty);
+};

--- a/Source/Flow/Public/Nodes/Variables/FlowNodeVariable.h
+++ b/Source/Flow/Public/Nodes/Variables/FlowNodeVariable.h
@@ -1,0 +1,25 @@
+﻿// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Nodes/FlowNode.h"
+#include "FlowNodeVariable.generated.h"
+
+/**
+ * A Flow Node Variable is similar to Flow Node with support for exposed Flow Property Bag variable.
+ */
+UCLASS(Abstract, Blueprintable)
+class FLOW_API UFlowNodeVariable : public UFlowNode
+{
+	GENERATED_BODY()
+	
+protected:
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (ExposeOnSpawn))
+	FFlowPropertyBag Property;
+
+public:
+
+	UFlowNodeVariable();
+};

--- a/Source/Flow/Public/Nodes/Variables/FlowNode_CreateProperty.h
+++ b/Source/Flow/Public/Nodes/Variables/FlowNode_CreateProperty.h
@@ -1,0 +1,29 @@
+﻿// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Nodes/FlowNode.h"
+#include "FlowNode_CreateProperty.generated.h"
+
+/**
+ * 
+ */
+UCLASS(NotBlueprintable, meta = (DisplayName = "Create Property", Keywords = "make, variable"))
+class FLOW_API UFlowNode_CreateProperty : public UFlowNode
+{
+	GENERATED_BODY()
+
+protected:
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (ExposeOnSpawn))
+	FFlowPropertyBag Property;
+
+public:
+
+	UFlowNode_CreateProperty();
+
+protected:
+	
+	virtual void ExecuteInput(const FName& PinName) override;
+};

--- a/Source/FlowEditor/Private/Graph/FlowGraphConnectionDrawingPolicy.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphConnectionDrawingPolicy.cpp
@@ -35,7 +35,6 @@ FFlowGraphConnectionDrawingPolicy::FFlowGraphConnectionDrawingPolicy(int32 InBac
 	// Cache off the editor options
 	RecentWireDuration = UFlowGraphSettings::Get()->RecentWireDuration;
 
-	InactiveColor = UFlowGraphSettings::Get()->InactiveWireColor;
 	RecentColor = UFlowGraphSettings::Get()->RecentWireColor;
 	RecordedColor = UFlowGraphSettings::Get()->RecordedWireColor;
 	SelectedColor = UFlowGraphSettings::Get()->SelectedWireColor;
@@ -170,7 +169,7 @@ void FFlowGraphConnectionDrawingPolicy::DetermineWiringStyle(UEdGraphPin* Output
 			}
 
 			// It's not followed, fade it and keep it thin
-			Params.WireColor = InactiveColor;
+			Params.WireColor = Schema->GetPinTypeColor(OutputPin->PinType);
 			Params.WireThickness = InactiveWireThickness;
 		}
 	}

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -84,6 +84,33 @@ void UFlowGraphSchema::CreateDefaultNodesForGraph(UEdGraph& Graph) const
 	CastChecked<UFlowGraph>(&Graph)->GetFlowAsset()->HarvestNodeConnections();
 }
 
+static FText GetPinIncompatibilityReason(const UEdGraphPin* PinA, const UEdGraphPin* PinB, bool* bIsFatalOut = nullptr)
+{
+	const FEdGraphPinType& PinAType = PinA->PinType;
+	const FEdGraphPinType& PinBType = PinB->PinType;
+
+	FFormatNamedArguments MessageArgs;
+	MessageArgs.Add(TEXT("PinAName"), PinA->GetDisplayName());
+	MessageArgs.Add(TEXT("PinBName"), PinB->GetDisplayName());
+	MessageArgs.Add(TEXT("PinAType"), UEdGraphSchema_K2::TypeToText(PinAType));
+	MessageArgs.Add(TEXT("PinBType"), UEdGraphSchema_K2::TypeToText(PinBType));
+
+	const UEdGraphPin* InputPin = (PinA->Direction == EGPD_Input) ? PinA : PinB;
+	const FEdGraphPinType& InputType = InputPin->PinType;
+	const UEdGraphPin* OutputPin = (InputPin == PinA) ? PinB : PinA;
+	const FEdGraphPinType& OutputType = OutputPin->PinType;
+
+	FText MessageFormat = LOCTEXT("DefaultPinIncompatibilityMessage", "{PinAType} is not compatible with {PinBType}.");
+
+	if (bIsFatalOut != nullptr)
+	{
+		// the incompatible pins should generate an error by default
+		*bIsFatalOut = true;
+	}
+
+	return FText::Format(MessageFormat, MessageArgs);
+}
+
 const FPinConnectionResponse UFlowGraphSchema::CanCreateConnection(const UEdGraphPin* PinA, const UEdGraphPin* PinB) const
 {
 	const UFlowGraphNode* OwningNodeA = Cast<UFlowGraphNode>(PinA->GetOwningNodeUnchecked());
@@ -114,6 +141,25 @@ const FPinConnectionResponse UFlowGraphSchema::CanCreateConnection(const UEdGrap
 		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, TEXT("Directions are not compatible"));
 	}
 
+	const bool bPinsAreCompatible = PinA->PinType.PinCategory.IsEqual(PinB->PinType.PinCategory);
+	if (bPinsAreCompatible == false)
+	{
+		bool bIsFatal = true;
+		const FText IncompatibleReason = GetPinIncompatibilityReason(PinA, PinB, &bIsFatal);
+		FPinConnectionResponse ConnectionResponse(CONNECT_RESPONSE_DISALLOW, IncompatibleReason.ToString());
+		if (bIsFatal)
+		{
+			ConnectionResponse.SetFatal();
+		}
+		return ConnectionResponse;
+	}
+
+	if (InputPin->PinType.PinCategory != PC_Exec)
+	{
+		constexpr ECanCreateConnectionResponse ReplyBreakInputs = CONNECT_RESPONSE_BREAK_OTHERS_AB;
+		return FPinConnectionResponse(ReplyBreakInputs, TEXT("Replace all existing connections"));
+	}
+
 	// Break existing connections on outputs only - multiple input connections are acceptable
 	if (OutputPin->LinkedTo.Num() > 0)
 	{
@@ -141,23 +187,36 @@ bool UFlowGraphSchema::ShouldHidePinDefaultValue(UEdGraphPin* Pin) const
 	return true;
 }
 
-FLinearColor UFlowGraphSchema::GetPinTypeColor(const FEdGraphPinType& PinType) const
-{
-	return FLinearColor::White;
-}
-
 void UFlowGraphSchema::BreakNodeLinks(UEdGraphNode& TargetNode) const
 {
-	Super::BreakNodeLinks(TargetNode);
+	// DO NOT CALL Super:: since UEdGraphSchema_K2 calls FindBlueprintForNodeChecked which will crash. Instead directly call from UEdGraphSchema.
+	// Same as Super::Super::BreakNodeLinks(TargetNode);
+	UEdGraphSchema::BreakNodeLinks(TargetNode);
 
 	TargetNode.GetGraph()->NotifyGraphChanged();
+}
+
+void UFlowGraphSchema::BreakSinglePinLink(UEdGraphPin* SourcePin, UEdGraphPin* TargetPin) const
+{
+	// DO NOT CALL Super:: since UEdGraphSchema_K2 calls FindBlueprintForNodeChecked which will crash. Instead directly call from UEdGraphSchema.
+	// Same as Super::Super::BreakSinglePinLink(SourcePin, TargetPin);
+	UEdGraphSchema::BreakSinglePinLink(SourcePin, TargetPin);
+}
+
+void UFlowGraphSchema::GetContextMenuActions(UToolMenu* Menu, UGraphNodeContextMenuContext* Context) const
+{
+	// DO NOT CALL Super:: since UEdGraphSchema_K2 calls FindBlueprintForNodeChecked which will crash. Instead directly call from UEdGraphSchema.
+	// Same as Super::Super::GetContextMenuActions(SourcePin, TargetPin);
+	UEdGraphSchema::GetContextMenuActions(Menu, Context);
 }
 
 void UFlowGraphSchema::BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNotification) const
 {
 	const FScopedTransaction Transaction(LOCTEXT("GraphEd_BreakPinLinks", "Break Pin Links"));
 
-	Super::BreakPinLinks(TargetPin, bSendsNodeNotification);
+	// DO NOT CALL Super:: since UEdGraphSchema_K2 calls FindBlueprintForNodeChecked which will crash. Instead directly call from UEdGraphSchema.
+	// Same as Super::Super::BreakPinLinks(TargetPin, bSendsNodeNotification);
+	UEdGraphSchema::BreakPinLinks(TargetPin, bSendsNodeNotification);
 
 	if (TargetPin.bOrphanedPin)
 	{
@@ -194,6 +253,7 @@ void UFlowGraphSchema::OnPinConnectionDoubleCicked(UEdGraphPin* PinA, UEdGraphPi
 	PinA->MakeLinkTo((PinA->Direction == EGPD_Output) ? NewReroute->InputPins[0] : NewReroute->OutputPins[0]);
 	PinB->MakeLinkTo((PinB->Direction == EGPD_Output) ? NewReroute->InputPins[0] : NewReroute->OutputPins[0]);
 }
+
 
 TArray<TSharedPtr<FString>> UFlowGraphSchema::GetFlowNodeCategories()
 {

--- a/Source/FlowEditor/Private/Graph/FlowGraphSettings.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSettings.cpp
@@ -22,7 +22,6 @@ UFlowGraphSettings::UFlowGraphSettings(const FObjectInitializer& ObjectInitializ
 	, ConnectionDrawType(EFlowConnectionDrawType::Default)
 	, CircuitConnectionAngle(45.f)
 	, CircuitConnectionSpacing(FVector2D(30.f))
-	, InactiveWireColor(FLinearColor(0.364f, 0.364f, 0.364f, 1.0f))
 	, InactiveWireThickness(1.5f)
 	, RecentWireDuration(3.0f)
 	, RecentWireColor(FLinearColor(1.0f, 0.05f, 0.0f, 1.0f))

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -25,6 +25,7 @@
 #include "SourceCodeNavigation.h"
 #include "Textures/SlateIcon.h"
 #include "ToolMenuSection.h"
+#include "Nodes/FlowPropertyHelpers.h"
 
 #define LOCTEXT_NAMESPACE "FlowGraphNode"
 
@@ -367,6 +368,18 @@ void UFlowGraphNode::AllocateDefaultPins()
 		for (const FFlowPin& OutputPin : FlowNode->OutputPins)
 		{
 			CreateOutputPin(OutputPin);
+		}
+
+		const auto FlowInputPin = FlowPropertyHelpers::GetInputFlowPropertyBag(FlowNode);
+		if (FlowInputPin.IsValid())
+		{
+			CreateInputPropertyPin(FlowInputPin);
+		}
+
+		const auto FlowOutputPin = FlowPropertyHelpers::GetOutputFlowPropertyBag(FlowNode);
+		if (FlowOutputPin.IsValid())
+		{
+			CreateOutputPropertyPin(FlowOutputPin);
 		}
 	}
 }
@@ -800,6 +813,28 @@ void UFlowGraphNode::CreateOutputPin(const FFlowPin& FlowPin, const int32 Index 
 	NewPin->PinToolTip = FlowPin.PinToolTip;
 
 	OutputPins.Emplace(NewPin);
+}
+
+void UFlowGraphNode::CreateInputPropertyPin(const FFlowPropertyBag& FlowPropertyPin, const int32 Index)
+{
+	check(!FlowPropertyPin.PropertyName.IsNone());
+
+	FCreatePinParams CreatePinParams;
+	CreatePinParams.Index = Index;
+	UEdGraphPin* NewPin = CreatePin(EGPD_Input, UEdGraphSchema_K2::PC_Struct, nullptr, FlowPropertyPin.PropertyName, CreatePinParams);
+	NewPin->PinToolTip = FlowPropertyPin.PinTooltip;
+	NewPin->PinType.PinSubCategoryObject = TBaseStructure<FFlowPropertyBag>::Get();
+}
+
+void UFlowGraphNode::CreateOutputPropertyPin(const FFlowPropertyBag& FlowPropertyPin, const int32 Index)
+{
+	check(!FlowPropertyPin.PropertyName.IsNone());
+
+	FCreatePinParams CreatePinParams;
+	CreatePinParams.Index = Index;
+	UEdGraphPin* NewPin = CreatePin(EGPD_Output, UEdGraphSchema_K2::PC_Struct, nullptr, FlowPropertyPin.PropertyName, CreatePinParams);
+	NewPin->PinToolTip = FlowPropertyPin.PinTooltip;
+	NewPin->PinType.PinSubCategoryObject = TBaseStructure<FFlowPropertyBag>::Get();
 }
 
 void UFlowGraphNode::RemoveOrphanedPin(UEdGraphPin* Pin)

--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -521,7 +521,15 @@ TSharedPtr<SWidget> SFlowGraphNode::GetEnabledStateWidget() const
 
 void SFlowGraphNode::CreateStandardPinWidget(UEdGraphPin* Pin)
 {
-	const TSharedPtr<SGraphPin> NewPin = SNew(SFlowGraphPinExec, Pin);
+	TSharedPtr<SGraphPin> NewPin;
+	if (Pin->PinType.PinCategory == UEdGraphSchema_K2::PC_Exec)
+	{
+		NewPin = SNew(SFlowGraphPinExec, Pin);
+	}
+	else
+	{
+		NewPin = SNew(SGraphPin, Pin);
+	}
 
 	if (!UFlowGraphSettings::Get()->bShowDefaultPinNames && FlowGraphNode->GetFlowNode())
 	{

--- a/Source/FlowEditor/Public/Graph/FlowGraphConnectionDrawingPolicy.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphConnectionDrawingPolicy.h
@@ -29,7 +29,6 @@ class FLOWEDITOR_API FFlowGraphConnectionDrawingPolicy : public FConnectionDrawi
 {
 	float RecentWireDuration;
 
-	FLinearColor InactiveColor;
 	FLinearColor RecentColor;
 	FLinearColor RecordedColor;
 	FLinearColor SelectedColor;

--- a/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "EdGraph/EdGraphSchema.h"
+#include "EdGraphSchema_K2.h"
 #include "FlowGraphSchema.generated.h"
 
 class UFlowAsset;
@@ -11,7 +11,7 @@ class UFlowNode;
 DECLARE_MULTICAST_DELEGATE(FFlowGraphSchemaRefresh);
 
 UCLASS()
-class FLOWEDITOR_API UFlowGraphSchema : public UEdGraphSchema
+class FLOWEDITOR_API UFlowGraphSchema : public UEdGraphSchema_K2
 {
 	GENERATED_UCLASS_BODY()
 
@@ -35,9 +35,10 @@ public:
 	virtual const FPinConnectionResponse CanCreateConnection(const UEdGraphPin* A, const UEdGraphPin* B) const override;
 	virtual bool TryCreateConnection(UEdGraphPin* A, UEdGraphPin* B) const override;
 	virtual bool ShouldHidePinDefaultValue(UEdGraphPin* Pin) const override;
-	virtual FLinearColor GetPinTypeColor(const FEdGraphPinType& PinType) const override;
 	virtual void BreakNodeLinks(UEdGraphNode& TargetNode) const override;
+	virtual void BreakSinglePinLink(UEdGraphPin* SourcePin, UEdGraphPin* TargetPin) const override;
 	virtual void BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNotification) const override;
+	virtual void GetContextMenuActions(UToolMenu* Menu, UGraphNodeContextMenuContext* Context) const override;
 	virtual int32 GetNodeSelectionCount(const UEdGraph* Graph) const override;
 	virtual TSharedPtr<FEdGraphSchemaAction> GetCreateCommentAction() const override;
 	virtual void OnPinConnectionDoubleCicked(UEdGraphPin* PinA, UEdGraphPin* PinB, const FVector2D& GraphPosition) const override;

--- a/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
@@ -79,9 +79,6 @@ class FLOWEDITOR_API UFlowGraphSettings : public UDeveloperSettings
 
 	UPROPERTY(config, EditAnywhere, Category = "Wires", meta = (EditCondition = "ConnectionDrawType == EFlowConnectionDrawType::Circuit"))
 	FVector2D CircuitConnectionSpacing;
-	
-	UPROPERTY(EditAnywhere, config, Category = "Wires")
-	FLinearColor InactiveWireColor;
 
 	UPROPERTY(EditAnywhere, config, Category = "Wires", meta = (ClampMin = 0.0f))
 	float InactiveWireThickness;

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -184,6 +184,12 @@ public:
 	void CreateInputPin(const FFlowPin& FlowPin, const int32 Index = INDEX_NONE);
 	void CreateOutputPin(const FFlowPin& FlowPin, const int32 Index = INDEX_NONE);
 
+private:
+	void CreateInputPropertyPin(const FFlowPropertyBag& FlowPropertyPin, const int32 Index = INDEX_NONE);
+	void CreateOutputPropertyPin(const FFlowPropertyBag& FlowPropertyPin, const int32 Index = INDEX_NONE);
+
+public:
+
 	void RemoveOrphanedPin(UEdGraphPin* Pin);
 
 	bool SupportsContextPins() const;


### PR DESCRIPTION
Added support for reading and writing variables in Flow Nodes.

You can create a custom **Flow Node** and add a new **Flow Property Bag** variable. Then make sure to set **Instance Editable** to true. This will expose the pin to **Flow Graph**.
![image](https://user-images.githubusercontent.com/5410301/219026629-e0ffcbbb-b2d7-4329-a642-0f5d2aa9463e.png)

Using any of the **Set Node** we can set the value of the property like this. Here I use **Set String** as an example.
![image](https://user-images.githubusercontent.com/5410301/219027149-cecc2d41-1a8e-468c-ac16-4e1f5c5f368e.png)

Then you can inherit from **Flow Node Variable**.
![image](https://user-images.githubusercontent.com/5410301/219024890-3e86003b-5812-4b17-918b-171c3f5aaf41.png)

You can now simply fetch the property using the member name you defined in the second screenshot.
![image](https://user-images.githubusercontent.com/5410301/219025568-83495bbd-a666-4c20-9163-a0c704d4659d.png)

Here is the Flow Graph connection
![image](https://user-images.githubusercontent.com/5410301/219029383-a1caf0c7-e5f3-482e-be4d-b1b665edf188.png)

Supports Execution overrides.
![image](https://user-images.githubusercontent.com/5410301/219029749-bd671952-a768-4f92-be5b-3bf83bb81ff6.png)

**Flow Subsystem Variables** exposes a lot of Get/Set nodes including UObject and UClasses.
![image](https://user-images.githubusercontent.com/5410301/219027495-4f718748-a18a-4361-9791-d125d734a958.png)

Alternatively, I've added a new node called **Create Property**. In the details panel, you can add as many properties as you want directly in Flow Graph.
![image](https://user-images.githubusercontent.com/5410301/219023866-d0eada33-bf5f-4680-858c-d0c96c7cba7a.png)
