### PR TITLE
Fix templated version of GetOwner

### DIFF
--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -242,7 +242,7 @@ public:
 	UObject* GetOwner() const { return Owner.Get(); }
 
 	template <class T>
-	TWeakObjectPtr<T*> GetOwner() const
+	TWeakObjectPtr<T> GetOwner() const
 	{
 		return Owner.IsValid() ? Cast<T>(Owner) : nullptr;
 	}


### PR DESCRIPTION
This fixes the templated version of GetOwner in Flow Asset from this:
```cpp
AActor** Actor = FlowAsset->GetOwner<AActor>().Get();
```
to this
```cpp
AActor* Actor = FlowAsset->GetOwner<AActor>().Get();
```