### PR TITLE
Show pretty readable pin name even if friendly name is not provided

### DIFF
--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -778,6 +778,7 @@ void UFlowGraphNode::CreateInputPin(const FFlowPin& FlowPin, const int32 Index /
 			NewPin->PinFriendlyName = FText::FromString(FName::NameToDisplayString(FlowPin.PinName.ToString(), false));
 		}
 	}
+	else
 	{
 		NewPin->bAllowFriendlyName = true;
 		NewPin->PinFriendlyName = FlowPin.PinFriendlyName;

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -25,6 +25,7 @@
 #include "SourceCodeNavigation.h"
 #include "Textures/SlateIcon.h"
 #include "ToolMenuSection.h"
+#include "Settings/EditorStyleSettings.h"
 
 #define LOCTEXT_NAMESPACE "FlowGraphNode"
 
@@ -769,7 +770,14 @@ void UFlowGraphNode::CreateInputPin(const FFlowPin& FlowPin, const int32 Index /
 	UEdGraphPin* NewPin = CreatePin(EGPD_Input, PinType, FlowPin.PinName, Index);
 	check(NewPin);
 
-	if (!FlowPin.PinFriendlyName.IsEmpty())
+	if (FlowPin.PinFriendlyName.IsEmpty())
+	{
+		if (GetDefault<UEditorStyleSettings>()->bShowFriendlyNames)
+		{
+			NewPin->bAllowFriendlyName = true;
+			NewPin->PinFriendlyName = FText::FromString(FName::NameToDisplayString(FlowPin.PinName.ToString(), false));
+		}
+	}
 	{
 		NewPin->bAllowFriendlyName = true;
 		NewPin->PinFriendlyName = FlowPin.PinFriendlyName;
@@ -791,7 +799,15 @@ void UFlowGraphNode::CreateOutputPin(const FFlowPin& FlowPin, const int32 Index 
 	UEdGraphPin* NewPin = CreatePin(EGPD_Output, PinType, FlowPin.PinName, Index);
 	check(NewPin);
 
-	if (!FlowPin.PinFriendlyName.IsEmpty())
+	if (FlowPin.PinFriendlyName.IsEmpty())
+	{
+		if (GetDefault<UEditorStyleSettings>()->bShowFriendlyNames)
+		{
+			NewPin->bAllowFriendlyName = true;
+			NewPin->PinFriendlyName = FText::FromString(FName::NameToDisplayString(FlowPin.PinName.ToString(), false));
+		}
+	}
+	else
 	{
 		NewPin->bAllowFriendlyName = true;
 		NewPin->PinFriendlyName = FlowPin.PinFriendlyName;


### PR DESCRIPTION
This change shows friendly name of the pin even if **_PinFriendlyName_** in **FFlowPin** is not provided so users don't have to keep setting readable name in **_PinFriendlyName_**. Of course they can still override and set it if they wish.

![image](https://user-images.githubusercontent.com/5410301/220034782-b1455c65-d7f7-41ab-9c0b-bfe4ad942e44.png)

This behavior is toggleable from **Editor Preferences** -> **Appearance** -> **Show Friendly Variables Names**
![image](https://user-images.githubusercontent.com/5410301/220035780-57b6e541-3cb6-46e9-b23a-b36685cb0757.png)
