### PR TITLE
Allow signal mode to be set at runtime

### DIFF
--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -512,6 +512,48 @@ void UFlowNode::Finish()
 	GetFlowAsset()->FinishNode(this);
 }
 
+bool UFlowNode::SetSignalModeRuntime(const EFlowSignalMode NewSignalMode)
+{
+	const UWorld* FlowWorld = GetWorld();
+	if (!IsValid(FlowWorld))
+	{
+		return false;
+	}
+
+	if (!FlowWorld->IsGameWorld())
+	{
+		LogError("'Set Signal Mode Runtime' should only be called at runtime.");
+		return false;
+	}
+	
+	if (SignalMode != NewSignalMode)
+	{
+#if WITH_EDITOR
+		if (!EditorSignalMode.IsSet())
+		{
+			EditorSignalMode = SignalMode;
+		}
+		UFlowAsset::GetFlowGraphInterface()->OnNodeSignalModeChangedRuntime(GetGraphNode(), NewSignalMode);
+#else
+		SignalMode = NewSignalMode;
+#endif
+
+		return true;
+	}
+
+	return false;
+}
+
+#if WITH_EDITOR
+void UFlowNode::ResetSignalMode()
+{
+	if (EditorSignalMode.IsSet())
+	{
+		UFlowAsset::GetFlowGraphInterface()->OnNodeSignalModeChangedRuntime(GetGraphNode(), EditorSignalMode.GetValue());
+	}
+}
+#endif
+
 void UFlowNode::Deactivate()
 {
 	if (GetFlowAsset()->FinishPolicy == EFlowFinishPolicy::Abort)

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -28,6 +28,8 @@ public:
 
 	virtual void OnInputTriggered(UEdGraphNode* GraphNode, const int32 Index) const {}
 	virtual void OnOutputTriggered(UEdGraphNode* GraphNode, const int32 Index) const {}
+
+	virtual void OnNodeSignalModeChangedRuntime(UEdGraphNode* GraphNode, const EFlowSignalMode NewSignalMode) const {}
 };
 
 DECLARE_DELEGATE(FFlowAssetEvent);
@@ -69,6 +71,13 @@ class FLOW_API UFlowAsset : public UObject
 	// --
 
 	virtual EDataValidationResult ValidateAsset(FFlowMessageLog& MessageLog);
+
+	void ResumePIE(const bool bIsSimulating);
+	void EndPIE(const bool bIsSimulating);
+
+protected:
+	virtual void OnResumePIE(const bool bIsSimulating) {}
+	virtual void OnEndPIE(const bool bIsSimulating) {}
 #endif
 
 	// IFlowGraphInterface

--- a/Source/Flow/Public/Nodes/FlowNode.h
+++ b/Source/Flow/Public/Nodes/FlowNode.h
@@ -130,6 +130,8 @@ protected:
 	EFlowSignalMode SignalMode;
 
 #if WITH_EDITOR
+	TOptional<EFlowSignalMode> EditorSignalMode;
+	
 	FFlowMessageLog ValidationLog;
 #endif
 
@@ -307,6 +309,14 @@ protected:
 	// Finish execution of node, it will call Cleanup
 	UFUNCTION(BlueprintCallable, Category = "FlowNode")
 	void Finish();
+
+	// Sets the signal mode. Should be used only at runtime.
+	UFUNCTION(BlueprintCallable, Category = "FlowNode")
+	bool SetSignalModeRuntime(const EFlowSignalMode NewSignalMode);
+
+#if WITH_EDITOR
+	void ResetSignalMode();
+#endif
 
 	void Deactivate();
 

--- a/Source/FlowEditor/Private/Graph/FlowGraph.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraph.cpp
@@ -19,6 +19,11 @@ void FFlowGraphInterface::OnOutputTriggered(UEdGraphNode* GraphNode, const int32
 	CastChecked<UFlowGraphNode>(GraphNode)->OnOutputTriggered(Index);
 }
 
+void FFlowGraphInterface::OnNodeSignalModeChangedRuntime(UEdGraphNode* GraphNode, const EFlowSignalMode NewSignalMode) const
+{
+	CastChecked<UFlowGraphNode>(GraphNode)->SetSignalMode(NewSignalMode);
+}
+
 UFlowGraph::UFlowGraph(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {

--- a/Source/FlowEditor/Public/Graph/FlowGraph.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraph.h
@@ -14,6 +14,7 @@ public:
 
 	virtual void OnInputTriggered(UEdGraphNode* GraphNode, const int32 Index) const override;
 	virtual void OnOutputTriggered(UEdGraphNode* GraphNode, const int32 Index) const override;
+	virtual void OnNodeSignalModeChangedRuntime(UEdGraphNode* GraphNode, const EFlowSignalMode NewSignalMode) const override;
 };
 
 UCLASS()


### PR DESCRIPTION
With this new node (and callable from C++) you can change signal mode at runtime. I made this for my use case where I need to run certain nodes only once and should technically disable itself once it runs its course. So instead of adding more logic specific to my needs I thought I'll make use of the existing signal mode. Setting **SignalMode** directly in Flow Node doesn't update it visually and once PIE ends it won't change back to the original state either. So I modified to make sure when this function is called, it will visually change the node (see the gif) and will reset back to the original state when PIE ends.

![image](https://user-images.githubusercontent.com/5410301/220311655-e72a91b2-c182-4989-92e6-52e45786182a.png)

![SetSignalMode](https://user-images.githubusercontent.com/5410301/220309578-f09744bc-2d75-4377-a8d4-d687fe88bea2.gif)
