### PR TITLE
Add an option to toggle signal mode logs

### DIFF
--- a/Source/Flow/Private/FlowSettings.cpp
+++ b/Source/Flow/Private/FlowSettings.cpp
@@ -6,5 +6,7 @@ UFlowSettings::UFlowSettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 	, bCreateFlowSubsystemOnClients(true)
 	, bWarnAboutMissingIdentityTags(true)
+	, bLogOnSignalDisabled(true)
+	, bLogOnSignalPassthrough(true)
 {
 }

--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -4,6 +4,7 @@
 
 #include "FlowAsset.h"
 #include "FlowModule.h"
+#include "FlowSettings.h"
 #include "FlowSubsystem.h"
 #include "FlowTypes.h"
 
@@ -427,10 +428,16 @@ void UFlowNode::TriggerInput(const FName& PinName, const EFlowPinActivationType 
 			ExecuteInput(PinName);
 			break;
 		case EFlowSignalMode::Disabled:
-			LogNote(FString::Printf(TEXT("Node disabled while triggering input %s"), *PinName.ToString()));
+			if (UFlowSettings::Get()->bLogOnSignalDisabled)
+			{
+				LogNote(FString::Printf(TEXT("Node disabled while triggering input %s"), *PinName.ToString()));
+			}
 			break;
 		case EFlowSignalMode::PassThrough:
-			LogNote(FString::Printf(TEXT("Signal pass-through on triggering input %s"), *PinName.ToString()));
+			if (UFlowSettings::Get()->bLogOnSignalPassthrough)
+			{
+				LogNote(FString::Printf(TEXT("Signal pass-through on triggering input %s"), *PinName.ToString()));
+			}
 			OnPassThrough();
 			break;
 		default: ;

--- a/Source/Flow/Public/FlowSettings.h
+++ b/Source/Flow/Public/FlowSettings.h
@@ -29,4 +29,12 @@ class FLOW_API UFlowSettings : public UDeveloperSettings
 	
 	UPROPERTY(Config, EditAnywhere, Category = "SaveSystem")
 	bool bWarnAboutMissingIdentityTags;
+
+	// If enabled, runtime logs will be added when a flow node signal mode is set to Disabled
+	UPROPERTY(Config, EditAnywhere, Category = "Flow")
+	bool bLogOnSignalDisabled;
+
+	// If enabled, runtime logs will be added when a flow node signal mode is set to Pass-through
+	UPROPERTY(Config, EditAnywhere, Category = "Flow")
+	bool bLogOnSignalPassthrough;
 };


### PR DESCRIPTION
For my use where I have a Timer that runs continuously and setting signal mode at runtime causes too much spam on the output log. By default these are enabled so it will work like before.

![image](https://user-images.githubusercontent.com/5410301/221549581-de582e6f-fd45-45f8-8809-4f03f105305e.png)