### PR TITLE
Add an option to toggle invoking of runtime tab

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
@@ -39,6 +39,7 @@
 #include "ScopedTransaction.h"
 #include "SNodePanel.h"
 #include "ToolMenus.h"
+#include "Graph/FlowGraphSettings.h"
 #include "Widgets/Docking/SDockTab.h"
 
 #if ENABLE_SEARCH_IN_ASSET_EDITOR
@@ -834,8 +835,11 @@ void FFlowAssetEditor::JumpToInnerObject(UObject* InnerObject)
 
 void FFlowAssetEditor::OnRuntimeMessageAdded(const UFlowAsset* AssetInstance, const TSharedRef<FTokenizedMessage>& Message) const
 {
-	// push messages to its window
-	TabManager->TryInvokeTab(RuntimeLogTab);
+	if (UFlowGraphSettings::Get()->bAutoFocusOnRuntimeMessageAdded)
+	{
+		// push messages to its window
+		TabManager->TryInvokeTab(RuntimeLogTab);
+	}
 	RuntimeLogListing->AddMessage(Message);
 	RuntimeLogListing->OnDataChanged().Broadcast();
 }

--- a/Source/FlowEditor/Private/Graph/FlowGraphSettings.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSettings.cpp
@@ -11,6 +11,7 @@ UFlowGraphSettings::UFlowGraphSettings(const FObjectInitializer& ObjectInitializ
 	, bExposeFlowAssetCreation(true)
 	, bExposeFlowNodeCreation(true)
 	, bShowAssetToolbarAboveLevelEditor(true)
+	, bAutoFocusOnRuntimeMessageAdded(false)
 	, FlowAssetCategoryName(LOCTEXT("FlowAssetCategory", "Flow"))
 	, DefaultFlowAssetClass(UFlowAsset::StaticClass())
 	, WorldAssetClass(UFlowAsset::StaticClass())

--- a/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
@@ -32,6 +32,10 @@ class FLOWEDITOR_API UFlowGraphSettings : public UDeveloperSettings
 	UPROPERTY(EditAnywhere, config, Category = "Default UI", meta = (ConfigRestartRequired = true))
 	bool bShowAssetToolbarAboveLevelEditor;
 
+	/** If enabled and when a runtime message is added, the target graph will automatically open and invokes runtime message tab. */
+	UPROPERTY(EditAnywhere, config, Category = "Default UI")
+	bool bAutoFocusOnRuntimeMessageAdded;
+
 	UPROPERTY(EditAnywhere, config, Category = "Default UI", meta = (ConfigRestartRequired = true))
 	FText FlowAssetCategoryName;
 


### PR DESCRIPTION
New option to toggle automatic invoking of runtime message tab. To understand why this PR is a good idea to merge is to create the following graph and run it.

![image](https://user-images.githubusercontent.com/5410301/221847820-3613d9f2-8448-4d0e-827b-1e562046f95c.png)

Now try to switch to another Blueprint or do anything in Unreal for the next 60 seconds 😜. Obviously the above graph is just an example but in any case, if someone wants to set a node pass through (or disabled) for the time being and experiment with something (while they execute that pass-through or disabled node in a timer or something), it can be an annoying experience being unable to do anything because of the invoking tab.

@MothDoctor I've set the option to false by default. In case you decide to merge this in, feel free to change `bAutoFocusOnRuntimeMessageAdded = true` if you want to.