### PR TITLE
Add an option to hide node description when PIE is active

### DIFF
--- a/Source/FlowEditor/Private/Graph/FlowGraphEditorSettings.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditorSettings.cpp
@@ -8,6 +8,7 @@ UFlowGraphEditorSettings::UFlowGraphEditorSettings(const FObjectInitializer& Obj
 	: Super(ObjectInitializer)
 	, NodeDoubleClickTarget(EFlowNodeDoubleClickTarget::PrimaryAsset)
 	, bShowNodeClass(false)
+	, bHideNodeDescriptionOnPIE(false)
 	, bShowSubGraphPreview(true)
 	, bShowSubGraphPath(true)
 	, SubGraphPreviewSize(FVector2D(640.f, 360.f))

--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -21,6 +21,7 @@
 #include "SNodePanel.h"
 #include "Styling/SlateColor.h"
 #include "TutorialMetaData.h"
+#include "Graph/FlowGraphEditorSettings.h"
 #include "Widgets/Images/SImage.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Layout/SBorder.h"
@@ -55,7 +56,7 @@ void SFlowGraphNode::Construct(const FArguments& InArgs, UFlowGraphNode* InNode)
 
 void SFlowGraphNode::GetNodeInfoPopups(FNodeInfoContext* Context, TArray<FGraphInformationPopupInfo>& Popups) const
 {
-	const FString Description = FlowGraphNode->GetNodeDescription();
+	const FString Description = GEditor->PlayWorld && UFlowGraphEditorSettings::Get()->bHideNodeDescriptionOnPIE ? "" : FlowGraphNode->GetNodeDescription();	
 	if (!Description.IsEmpty())
 	{
 		const FGraphInformationPopupInfo DescriptionPopup = FGraphInformationPopupInfo(nullptr, UFlowGraphSettings::Get()->NodeDescriptionBackground, Description);

--- a/Source/FlowEditor/Public/Graph/FlowGraphEditorSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphEditorSettings.h
@@ -30,6 +30,10 @@ class FLOWEDITOR_API UFlowGraphEditorSettings : public UDeveloperSettings
 	UPROPERTY(config, EditAnywhere, Category = "Nodes")
 	bool bShowNodeClass;
 
+	// Hides the node description when you play in editor and only shows node status string.
+	UPROPERTY(config, EditAnywhere, Category = "Nodes")
+	bool bHideNodeDescriptionOnPIE;
+
 	// Renders preview of entire graph while hovering over 
 	UPROPERTY(config, EditAnywhere, Category = "Nodes")
 	bool bShowSubGraphPreview;


### PR DESCRIPTION
For quick readability you can hide node description temporarily while PIE is active. By default it is off so old behavior is kept.

GIF:
![NodeDescriptionHide](https://user-images.githubusercontent.com/5410301/222068600-b48e6b99-06b7-4ac2-bd78-1fbd4449b11a.gif)
