### PR TITLE
Fixed bug where Owner parameter wasn't being used 

### DIFF
--- a/Source/Flow/Private/FlowComponent.cpp
+++ b/Source/Flow/Private/FlowComponent.cpp
@@ -385,9 +385,11 @@ void UFlowComponent::FinishRootFlow(UFlowAsset* TemplateAsset, const EFlowFinish
 
 TSet<UFlowAsset*> UFlowComponent::GetRootInstances(const UObject* Owner) const
 {
+	const UObject* OwnerToCheck = IsValid(Owner) ? Owner : this;
+
 	if (const UFlowSubsystem* FlowSubsystem = GetFlowSubsystem())
 	{
-		return FlowSubsystem->GetRootInstancesByOwner(this);
+		return FlowSubsystem->GetRootInstancesByOwner(OwnerToCheck);
 	}
 
 	return TSet<UFlowAsset*>();

--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -11,6 +11,7 @@
 
 #include "Engine/GameInstance.h"
 #include "Engine/World.h"
+#include "Logging/MessageLog.h"
 #include "Misc/Paths.h"
 #include "UObject/UObjectHash.h"
 

--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -8,6 +8,9 @@
 #include "FlowSubsystem.h"
 #include "FlowTypes.h"
 
+#if WITH_EDITOR
+#include "Editor.h"
+#endif
 #include "Engine/Engine.h"
 #include "Engine/ViewportStatsSubsystem.h"
 #include "Engine/World.h"

--- a/Source/FlowEditor/Private/Asset/FlowAssetToolbar.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetToolbar.cpp
@@ -11,6 +11,7 @@
 
 #include "Kismet2/DebuggerCommands.h"
 #include "Misc/Attribute.h"
+#include "Misc/MessageDialog.h"
 #include "Subsystems/AssetEditorSubsystem.h"
 #include "ToolMenu.h"
 #include "ToolMenuSection.h"

--- a/Source/FlowEditor/Private/Asset/FlowImportUtils.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowImportUtils.cpp
@@ -13,6 +13,7 @@
 
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetToolsModule.h"
+#include "EdGraphSchema_K2.h"
 #include "EditorAssetLibrary.h"
 #include "Misc/ScopedSlowTask.h"
 

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -20,6 +20,7 @@
 #include "Editor/EditorEngine.h"
 #include "Framework/Commands/GenericCommands.h"
 #include "GraphEditorActions.h"
+#include "HAL/FileManager.h"
 #include "Kismet2/KismetEditorUtilities.h"
 #include "ScopedTransaction.h"
 #include "SourceCodeNavigation.h"

--- a/Source/FlowEditor/Public/Asset/FlowDebuggerSubsystem.h
+++ b/Source/FlowEditor/Public/Asset/FlowDebuggerSubsystem.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "EditorSubsystem.h"
+#include "Logging/TokenizedMessage.h"
 #include "FlowDebuggerSubsystem.generated.h"
 
 class UFlowAsset;

--- a/Source/FlowEditor/Public/Asset/FlowImportUtils.h
+++ b/Source/FlowEditor/Public/Asset/FlowImportUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "FlowAsset.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
 #include "Nodes/FlowPin.h"
 #include "FlowImportUtils.generated.h"
 


### PR DESCRIPTION
Owner was passed into this UFlowComponent::GetRootInstances(), presumably to be used instead of 'this', but it was just using 'this'.

Changed the code to use Owner if specified, and default to 'this' otherwise.