### PR TITLE
Fix JumpToInnerObject not working when SearchTree provides the GraphNode itself

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
@@ -539,6 +539,10 @@ void FFlowAssetEditor::JumpToInnerObject(UObject* InnerObject)
 	{
 		GraphEditor->JumpToNode(FlowNode->GetGraphNode(), true);
 	}
+	else if (const UEdGraphNode* GraphNode = Cast<UEdGraphNode>(InnerObject))
+	{
+		GraphEditor->JumpToNode(GraphNode, true);
+	}
 }
 #endif
 


### PR DESCRIPTION
After making the corresponding engine changes, I found that - depending on the exact search term that was entered - the SearchTree would sometimes provide the GraphNode instead of the FlowNode for a particular node. As a result, the focus failed.

This just adds handling for when that happens and I have not had any further issues with focus.