### PR TITLE
Add validation error on FlowAsset for disallowed node classes

### DIFF
--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -71,6 +71,11 @@ class FLOW_API UFlowAsset : public UObject
 	// --
 
 	virtual EDataValidationResult ValidateAsset(FFlowMessageLog& MessageLog);
+
+	// Returns whether the node class is allowed in this flow asset
+	bool IsNodeClassAllowed(const UClass* FlowNodeClass) const;
+
+	static FString ValidationError_NodeClassNotAllowed;
 #endif
 
 	// IFlowGraphInterface

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -353,64 +353,17 @@ void UFlowGraphSchema::ApplyNodeFilter(const UFlowAsset* AssetClassDefaults, con
 		return;
 	}
 
+	if (AssetClassDefaults == nullptr)
+	{
+		return;
+	}
+
+	if (!AssetClassDefaults->IsNodeClassAllowed(FlowNodeClass))
+	{
+		return;
+	}
+	
 	UFlowNode* NodeDefaults = FlowNodeClass->GetDefaultObject<UFlowNode>();
-
-	// UFlowNode class limits which UFlowAsset class can use it
-	{
-		for (const UClass* DeniedAssetClass : NodeDefaults->DeniedAssetClasses)
-		{
-			if (DeniedAssetClass && AssetClassDefaults->GetClass()->IsChildOf(DeniedAssetClass))
-			{
-				return;
-			}
-		}
-
-		if (NodeDefaults->AllowedAssetClasses.Num() > 0)
-		{
-			bool bAllowedInAsset = false;
-			for (const UClass* AllowedAssetClass : NodeDefaults->AllowedAssetClasses)
-			{
-				if (AllowedAssetClass && AssetClassDefaults->GetClass()->IsChildOf(AllowedAssetClass))
-				{
-					bAllowedInAsset = true;
-					break;
-				}
-			}
-			if (!bAllowedInAsset)
-			{
-				return;
-			}
-		}
-	}
-
-	// UFlowAsset class can limit which UFlowNode classes can be used
-	{
-		for (const UClass* DeniedNodeClass : AssetClassDefaults->DeniedNodeClasses)
-		{
-			if (DeniedNodeClass && FlowNodeClass->IsChildOf(DeniedNodeClass))
-			{
-				return;
-			}
-		}
-
-		if (AssetClassDefaults->AllowedNodeClasses.Num() > 0)
-		{
-			bool bAllowedInAsset = false;
-			for (const UClass* AllowedNodeClass : AssetClassDefaults->AllowedNodeClasses)
-			{
-				if (AllowedNodeClass && FlowNodeClass->IsChildOf(AllowedNodeClass))
-				{
-					bAllowedInAsset = true;
-					break;
-				}
-			}
-			if (!bAllowedInAsset)
-			{
-				return;
-			}
-		}
-	}
-
 	FilteredNodes.Emplace(NodeDefaults);
 }
 


### PR DESCRIPTION
Validation was not checking for disallowed node classes in a flow asset, which can happen if the node classes allowed were changed after nodes were added to the graph. 

To not duplicate the node class allowed logic, I've encapsulated it in a function on the flow asset and it is being called by the validation and schema. 