### PR TITLE
Add ability for FlowAsset child classes to define if they are allowed in subgraph nodes

### DIFF
--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -23,6 +23,7 @@ UFlowAsset::UFlowAsset(const FObjectInitializer& ObjectInitializer)
 	, FlowGraph(nullptr)
 #endif
 	, AllowedNodeClasses({UFlowNode::StaticClass()})
+	, AllowedInSubgraphNodeClasses({UFlowNode_SubGraph::StaticClass()})
 	, bStartNodePlacedAsGhostNode(false)
 	, TemplateAsset(nullptr)
 	, FinishPolicy(EFlowFinishPolicy::Keep)

--- a/Source/Flow/Private/Nodes/Route/FlowNode_SubGraph.cpp
+++ b/Source/Flow/Private/Nodes/Route/FlowNode_SubGraph.cpp
@@ -16,6 +16,8 @@ UFlowNode_SubGraph::UFlowNode_SubGraph(const FObjectInitializer& ObjectInitializ
 #if WITH_EDITOR
 	Category = TEXT("Route");
 	NodeStyle = EFlowNodeStyle::SubGraph;
+
+	AllowedAssignedAssetClasses = {UFlowAsset::StaticClass()};
 #endif
 
 	InputPins = {StartPin};

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -48,6 +48,7 @@ class FLOW_API UFlowAsset : public UObject
 	friend class UFlowSubsystem;
 
 	friend class FFlowAssetDetails;
+	friend class FFlowNode_SubGraphDetails;
 	friend class UFlowGraphSchema;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Flow Asset")
@@ -99,6 +100,9 @@ protected:
 	TArray<TSubclassOf<UFlowNode>> AllowedNodeClasses;
 	TArray<TSubclassOf<UFlowNode>> DeniedNodeClasses;
 
+	TArray<TSubclassOf<UFlowNode>> AllowedInSubgraphNodeClasses;
+	TArray<TSubclassOf<UFlowNode>> DeniedInSubgraphNodeClasses;
+	
 	bool bStartNodePlacedAsGhostNode;
 
 private:

--- a/Source/Flow/Public/Nodes/Route/FlowNode_SubGraph.h
+++ b/Source/Flow/Public/Nodes/Route/FlowNode_SubGraph.h
@@ -14,6 +14,7 @@ class FLOW_API UFlowNode_SubGraph : public UFlowNode
 	GENERATED_UCLASS_BODY()
 
 	friend class UFlowAsset;
+	friend class FFlowNode_SubGraphDetails;
 	friend class UFlowSubsystem;
 
 	static FFlowPin StartPin;
@@ -48,8 +49,20 @@ public:
 protected:
 	virtual void OnLoad_Implementation() override;
 
-public:
+
+#if WITH_EDITORONLY_DATA
+protected:
+	// All the classes allowed to be used as assets on this subgraph node
+	UPROPERTY()
+	TArray<TSubclassOf<UFlowAsset>> AllowedAssignedAssetClasses;
+
+	// All the classes disallowed to be used as assets on this subgraph node
+	UPROPERTY()
+	TArray<TSubclassOf<UFlowAsset>> DeniedAssignedAssetClasses;
+#endif
+
 #if WITH_EDITOR
+public:
 	virtual FString GetNodeDescription() const override;
 	virtual UObject* GetAssetToEdit() override;
 	virtual EDataValidationResult ValidateNode() override;

--- a/Source/FlowEditor/Private/DetailCustomizations/FlowNode_SubGraphDetails.cpp
+++ b/Source/FlowEditor/Private/DetailCustomizations/FlowNode_SubGraphDetails.cpp
@@ -1,0 +1,70 @@
+﻿// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#include "DetailCustomizations/FlowNode_SubGraphDetails.h"
+
+#include "DetailLayoutBuilder.h"
+#include "FlowAsset.h"
+#include "Nodes/Route/FlowNode_SubGraph.h"
+
+void FFlowNode_SubGraphDetails::CustomizeDetails(IDetailLayoutBuilder& DetailLayout)
+{
+	TArray<TWeakObjectPtr<UObject>> ObjectsBeingEdited;
+	DetailLayout.GetObjectsBeingCustomized(ObjectsBeingEdited);
+
+	if (ObjectsBeingEdited[0].IsValid())
+	{
+		const UFlowNode_SubGraph* SubGraphNode = CastChecked<UFlowNode_SubGraph>(ObjectsBeingEdited[0]);
+
+		// Generate the list of asset classes allowed or disallowed
+		TArray<UClass*> FlowAssetClasses;
+		GetDerivedClasses(UFlowAsset::StaticClass(), FlowAssetClasses, true);
+		FlowAssetClasses.Add(UFlowAsset::StaticClass());
+
+		TArray<UClass*> DisallowedClasses;
+		TArray<UClass*> AllowedClasses;
+		for (auto FlowAssetClass : FlowAssetClasses)
+		{
+			if (const UFlowAsset* DefaultAsset = Cast<UFlowAsset>(FlowAssetClass->GetDefaultObject()))
+			{
+				if (DefaultAsset->DeniedInSubgraphNodeClasses.Contains(SubGraphNode->GetClass()))
+				{
+					DisallowedClasses.Add(FlowAssetClass);
+				}
+	
+				if (DefaultAsset->AllowedInSubgraphNodeClasses.Contains(SubGraphNode->GetClass()))
+				{
+					AllowedClasses.Add(FlowAssetClass);
+				}
+			}
+		}
+	
+		DisallowedClasses.Append(SubGraphNode->DeniedAssignedAssetClasses);
+	
+		for (auto FlowAssetClass : SubGraphNode->AllowedAssignedAssetClasses)
+		{
+			if (!DisallowedClasses.Contains(FlowAssetClass))
+			{
+				AllowedClasses.AddUnique(FlowAssetClass);
+			}
+		}
+	
+		FString AllowedClassesString;
+		for (UClass* Class : AllowedClasses)
+		{
+			AllowedClassesString.Append(FString::Printf(TEXT("%s,"), *Class->GetClassPathName().ToString()));
+		}
+	
+		FString DisallowedClassesString;
+		for (UClass* Class : DisallowedClasses)
+		{
+			DisallowedClassesString.Append(FString::Printf(TEXT("%s,"), *Class->GetClassPathName().ToString()));
+		}
+	
+		const auto AssetProperty = DetailLayout.GetProperty(FName("Asset"), UFlowNode_SubGraph::StaticClass());
+		if (FProperty* MetaDataProperty = AssetProperty->GetMetaDataProperty())
+		{
+			MetaDataProperty->SetMetaData(TEXT("AllowedClasses"), *AllowedClassesString);
+			MetaDataProperty->SetMetaData(TEXT("DisallowedClasses"), *DisallowedClassesString);
+		}
+	}
+}

--- a/Source/FlowEditor/Private/FlowEditorModule.cpp
+++ b/Source/FlowEditor/Private/FlowEditorModule.cpp
@@ -20,10 +20,12 @@
 #include "DetailCustomizations/FlowNode_CustomInputDetails.h"
 #include "DetailCustomizations/FlowNode_CustomOutputDetails.h"
 #include "DetailCustomizations/FlowNode_PlayLevelSequenceDetails.h"
+#include "DetailCustomizations/FlowNode_SubGraphDetails.h"
 
 #include "FlowAsset.h"
 #include "Nodes/Route/FlowNode_CustomInput.h"
 #include "Nodes/Route/FlowNode_CustomOutput.h"
+#include "Nodes/Route/FlowNode_SubGraph.h"
 #include "Nodes/World/FlowNode_ComponentObserver.h"
 #include "Nodes/World/FlowNode_PlayLevelSequence.h"
 
@@ -77,6 +79,7 @@ void FFlowEditorModule::StartupModule()
 	RegisterCustomClassLayout(UFlowNode_CustomInput::StaticClass(), FOnGetDetailCustomizationInstance::CreateStatic(&FFlowNode_CustomInputDetails::MakeInstance));
 	RegisterCustomClassLayout(UFlowNode_CustomOutput::StaticClass(), FOnGetDetailCustomizationInstance::CreateStatic(&FFlowNode_CustomOutputDetails::MakeInstance));
 	RegisterCustomClassLayout(UFlowNode_PlayLevelSequence::StaticClass(), FOnGetDetailCustomizationInstance::CreateStatic(&FFlowNode_PlayLevelSequenceDetails::MakeInstance));
+	RegisterCustomClassLayout(UFlowNode_SubGraph::StaticClass(), FOnGetDetailCustomizationInstance::CreateStatic(&FFlowNode_SubGraphDetails::MakeInstance));
 
 	FPropertyEditorModule& PropertyModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
 	PropertyModule.NotifyCustomizationModuleChanged();

--- a/Source/FlowEditor/Public/DetailCustomizations/FlowNode_SubGraphDetails.h
+++ b/Source/FlowEditor/Public/DetailCustomizations/FlowNode_SubGraphDetails.h
@@ -1,0 +1,16 @@
+﻿// Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
+
+#pragma once
+
+#include "IDetailCustomization.h"
+
+class FFlowNode_SubGraphDetails final : public IDetailCustomization
+{
+public:
+	static TSharedRef<IDetailCustomization> MakeInstance()
+	{
+		return MakeShareable(new FFlowNode_SubGraphDetails);
+	}
+
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailLayout) override;
+};


### PR DESCRIPTION
~~To prevent custom FlowAsset classes to be instantiated by a subgraph node, this PR adds:~~
~~- A virtual method that returns if the class can be used in subgraph nodes~~
~~- Manually setting the **DisallowedClasses** meta specifier on the subgraph node Asset UProperty~~
~~- A validation rule on subgraph nodes~~
