### PR TITLE
Consolidate settings

### DIFF
--- a/Source/Flow/Public/FlowSettings.h
+++ b/Source/Flow/Public/FlowSettings.h
@@ -42,4 +42,12 @@ class FLOW_API UFlowSettings : public UDeveloperSettings
 	// by incorporating data that would otherwise go in the Description
 	UPROPERTY(EditAnywhere, config, Category = "Nodes")
 	bool bUseAdaptiveNodeTitles;
+
+public:
+
+#if WITH_EDITORONLY_DATA
+	virtual FName GetCategoryName() const override { return FName("Flow Graph"); }
+	virtual FText GetSectionText() const override { return INVTEXT("Settings"); }
+#endif
+	
 };

--- a/Source/FlowEditor/Public/Graph/FlowGraphEditorSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphEditorSettings.h
@@ -53,4 +53,9 @@ class FLOWEDITOR_API UFlowGraphEditorSettings : public UDeveloperSettings
 
 	UPROPERTY(EditAnywhere, config, Category = "Wires")
 	bool bHighlightOutputWiresOfSelectedNodes;
+
+public:
+
+	virtual FName GetCategoryName() const override { return FName("Flow Graph"); }
+	virtual FText GetSectionText() const override { return INVTEXT("Editor Settings"); }
 };

--- a/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
@@ -106,4 +106,9 @@ class FLOWEDITOR_API UFlowGraphSettings : public UDeveloperSettings
 
 	UPROPERTY(EditAnywhere, config, Category = "Wires", meta = (ClampMin = 0.0f))
 	float SelectedWireThickness;
+
+public:
+	
+	virtual FName GetCategoryName() const override { return FName("Flow Graph"); }
+	virtual FText GetSectionText() const override { return INVTEXT("Graph Settings"); }
 };


### PR DESCRIPTION
Before Flow settings were scattered around and was hard to find so I've organized them into one place. Now you can find them in: 

**Project Settings**
![image](https://github.com/MothCocoon/FlowGraph/assets/5410301/d64d5025-3ded-4ca4-9007-a2c57858ba5f)

**Editor Settings**
![image](https://github.com/MothCocoon/FlowGraph/assets/5410301/811882d2-1f47-4f33-b052-10dddc6a1b8f)

Previously they were here:
```
Editor Preferences -> General -> Flow Graph
Project Settinngs -> Editor -> Flow Graph
Project Settings -> Game -> Flow
```