### PR TITLE
Fixed crash when doing a diff of a Flow Graph vs Perforce.

### DIFF
--- a/Source/FlowEditor/Private/Asset/SFlowDiff.cpp
+++ b/Source/FlowEditor/Private/Asset/SFlowDiff.cpp
@@ -722,6 +722,7 @@ SFlowDiff::FDiffControl SFlowDiff::GenerateDetailsPanel()
 #endif	
 
 	SFlowDiff::FDiffControl Ret;
+	Ret.Widget = SNullWidget::NullWidget;
 	Ret.DiffControl = NewDiffControl;
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 3


### PR DESCRIPTION
The crash occurred inside of the SetContent method called from SFlowDiff::SetCurrentMode. When the Widget is not set to SNullWidget::NullWidget it assumes that the widget exists and attempts to dereference it, but in the former code the Widget was unset (nullptr) causing the crash.