### PR TITLE
allows to setup a mapping between gameplay tags and sequence tags.

### DIFF
--- a/Source/Flow/Private/Nodes/World/FlowNode_PlayLevelSequence.cpp
+++ b/Source/Flow/Private/Nodes/World/FlowNode_PlayLevelSequence.cpp
@@ -153,6 +153,18 @@ void UFlowNode_PlayLevelSequence::CreatePlayer()
 		// Finally create the player
 		SequencePlayer = UFlowLevelSequencePlayer::CreateFlowLevelSequencePlayer(this, LoadedSequence, PlaybackSettings, CameraSettings, TransformOriginActor, bReplicates, bAlwaysRelevant, SequenceActor);
 
+		// Bind Actors with GameTags to Sequence-Tags
+		for (auto& [key_gp_tag, val_seq_tag] : BindActorsFromIdentityTagToSequenceTags)
+		{
+			auto actors = GetFlowSubsystem()->GetFlowActorsByTag(key_gp_tag, AActor::StaticClass());
+
+			for (const auto first : actors)
+			{
+				SequenceActor->AddBindingByTag(val_seq_tag, first);
+				break; // just taking first.
+			}
+		}
+
 		if (SequencePlayer)
 		{
 			SequencePlayer->SetFlowEventReceiver(this);

--- a/Source/Flow/Public/Nodes/World/FlowNode_PlayLevelSequence.h
+++ b/Source/Flow/Public/Nodes/World/FlowNode_PlayLevelSequence.h
@@ -62,6 +62,10 @@ public:
 	UPROPERTY(EditAnywhere, Category = "Sequence")
 	bool bApplyOwnerTimeDilation;
 	
+	// Allows Binding of Tagged Sequences to Actors via Registered FlowActors / GameTags.
+	UPROPERTY(EditAnywhere, Category = "Sequence|Bindings")
+	TMap<FGameplayTag, FName> BindActorsFromIdentityTagToSequenceTags;
+
 protected:
 	UPROPERTY()
 	ULevelSequence* LoadedSequence;


### PR DESCRIPTION
  It uses the Actors that register via the FlowComponent's IdentityTags.
  Within the node the designer can define the mapping

The Example Sequence:
![image](https://github.com/MothCocoon/FlowGraph/assets/3066582/096d2a89-308c-4b87-9e20-f1491da797a0)

The FlowNode:
![image](https://github.com/MothCocoon/FlowGraph/assets/3066582/548439fb-e1a8-4677-912e-8514a4f6de4d)

Possible Future Improvements:
- Like the Sequence Events, that are auto detected, one could check which tags are available at all. either to validate, or to prepoluate the Map (note that the map would be the other way around, then)