### PR TITLE
fixes missing indentation in the palette panel for subcategories

### DIFF
--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowPalette.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowPalette.cpp
@@ -105,6 +105,17 @@ void SFlowPalette::Construct(const FArguments& InArgs, TWeakPtr<FFlowAssetEditor
 	UpdateCategoryNames();
 	UFlowGraphSchema::OnNodeListChanged.AddSP(this, &SFlowPalette::Refresh);
 
+	struct LocalUtils
+	{
+		static TSharedRef<SExpanderArrow> CreateCustomExpanderStatic(const FCustomExpanderData& ActionMenuData, bool bShowFavoriteToggle)
+		{
+			TSharedPtr<SExpanderArrow> CustomExpander;
+			// in SBlueprintSubPalette here would be a difference depending on bShowFavoriteToggle
+			SAssignNew(CustomExpander, SExpanderArrow, ActionMenuData.TableRow);
+			return CustomExpander.ToSharedRef();
+		}
+	};
+
 	this->ChildSlot
 	[
 		SNew(SBorder)
@@ -134,6 +145,7 @@ void SFlowPalette::Construct(const FArguments& InArgs, TWeakPtr<FFlowAssetEditor
 							.OnActionSelected(this, &SFlowPalette::OnActionSelected)
 							.OnCreateWidgetForAction(this, &SFlowPalette::OnCreateWidgetForAction)
 							.OnCollectAllActions(this, &SFlowPalette::CollectAllActions)
+							.OnCreateCustomRowExpander_Static(&LocalUtils::CreateCustomExpanderStatic, false)
 							.AutoExpandActionMenu(true)
 					]
 			]


### PR DESCRIPTION
  using a custom "RowExpander" Delegate analogous to the way the blueprint graph does it.
  compare it to here: https://github.com/EpicGames/UnrealEngine/blob/072300df18a94f18077ca20a14224b5d99fee872/Engine/Source/Editor/Kismet/Private/SBlueprintSubPalette.cpp#L293C54-L293C74

fixes #181 
