### PR TITLE
Update FlowGraph Reroute Node Selection & Connection Highlighting to be similar to Blueprints. Resolves #171

### DIFF
--- a/Source/FlowEditor/Private/Graph/FlowGraphConnectionDrawingPolicy.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphConnectionDrawingPolicy.cpp
@@ -196,6 +196,14 @@ void FFlowGraphConnectionDrawingPolicy::DetermineWiringStyle(UEdGraphPin* Output
 			}
 		}
 	}
+
+	const bool bDeemphasizeUnhoveredPins = HoveredPins.Num() > 0;
+
+	if (bDeemphasizeUnhoveredPins)
+	{
+		ApplyHoverDeemphasis(OutputPin, InputPin, /*inout*/ Params.WireThickness, /*inout*/ Params.WireColor);
+	}
+
 }
 
 void FFlowGraphConnectionDrawingPolicy::Draw(TMap<TSharedRef<SWidget>, FArrangedWidget>& InPinGeometries, FArrangedChildren& ArrangedNodes)

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditorSettings.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditorSettings.cpp
@@ -12,7 +12,7 @@ UFlowGraphEditorSettings::UFlowGraphEditorSettings(const FObjectInitializer& Obj
 	, bShowSubGraphPath(true)
 	, SubGraphPreviewSize(FVector2D(640.f, 360.f))
 	, bHotReloadNativeNodes(false)
-	, bHighlightInputWiresOfSelectedNodes(true)
+	, bHighlightInputWiresOfSelectedNodes(false)
 	, bHighlightOutputWiresOfSelectedNodes(false)
 {
 }

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditorSettings.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditorSettings.cpp
@@ -11,7 +11,7 @@ UFlowGraphEditorSettings::UFlowGraphEditorSettings(const FObjectInitializer& Obj
 	, bShowSubGraphPreview(true)
 	, bShowSubGraphPath(true)
 	, SubGraphPreviewSize(FVector2D(640.f, 360.f))
-	, bHighlightInputWiresOfSelectedNodes(true)
+	, bHighlightInputWiresOfSelectedNodes(false)
 	, bHighlightOutputWiresOfSelectedNodes(false)
 {
 }

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditorSettings.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditorSettings.cpp
@@ -11,6 +11,7 @@ UFlowGraphEditorSettings::UFlowGraphEditorSettings(const FObjectInitializer& Obj
 	, bShowSubGraphPreview(true)
 	, bShowSubGraphPath(true)
 	, SubGraphPreviewSize(FVector2D(640.f, 360.f))
+	, bHotReloadNativeNodes(false)
 	, bHighlightInputWiresOfSelectedNodes(false)
 	, bHighlightOutputWiresOfSelectedNodes(false)
 {


### PR DESCRIPTION
**Change 1:** When mouse cursor moves over a connection, the connection now highlights. This is similar to how connection highlighting is done in Blueprints.

![image](https://github.com/MothCocoon/FlowGraph/assets/149346422/a76872b9-a612-482c-b36c-8549e96f1e6d)

**Change 2:** From Feedback #171, when reroute nodes are selected, in a reverse loop, the loop does not reverse. This is due to reroute nodes, when selected, also highlighting the "in" connection, leading to the loop not reversing. This pull request changes reroute node selection to not highlight the "in" connection - similar to how reroute node selection is done in Blueprints.

![image](https://github.com/MothCocoon/FlowGraph/assets/149346422/7f83f834-cba0-4fea-8dda-ee420682c08c)

