### PR TITLE
Fix UFlowNode_SubGraph in cooked builds where Asset member could dere…

### DIFF
--- a/Source/Flow/Private/Nodes/Route/FlowNode_SubGraph.cpp
+++ b/Source/Flow/Private/Nodes/Route/FlowNode_SubGraph.cpp
@@ -26,7 +26,7 @@ UFlowNode_SubGraph::UFlowNode_SubGraph(const FObjectInitializer& ObjectInitializ
 
 bool UFlowNode_SubGraph::CanBeAssetInstanced() const
 {
-	return !Asset.IsNull() && (bCanInstanceIdenticalAsset || Asset->GetPathName() != GetFlowAsset()->GetTemplateAsset()->GetPathName());
+	return !Asset.IsNull() && (bCanInstanceIdenticalAsset || Asset.ToString() != GetFlowAsset()->GetTemplateAsset()->GetPathName());
 }
 
 void UFlowNode_SubGraph::PreloadContent()
@@ -55,7 +55,7 @@ void UFlowNode_SubGraph::ExecuteInput(const FName& PinName)
 		}
 		else
 		{
-			LogError(FString::Printf(TEXT("Asset %s cannot be instance, probably is the same as the asset owning this SubGraph node."), *Asset->GetPathName()));
+			LogError(FString::Printf(TEXT("Asset %s cannot be instance, probably is the same as the asset owning this SubGraph node."), *Asset.ToString()));
 		}
 		
 		Finish();


### PR DESCRIPTION
…ference to nullptr, when trying to get the PathName after converting to UObject*. Just try to get the Path Name from the SoftObjectPtr itself instead.

Reason: UObjectBaseUtility::GetPathName() has a check with a if (this != NULL) and under clang, in optimized builds, this is assumed to be always true. Depending on how inlining goes, the compiler is free to eliminate if it assumes it will always be true; chcked generated UE 5.2 and UE 5.3 code in disassembly, and the checks for if(this != StopOuter && this != NULL) was outright eliminated during aggressive inlining and was assumed to be true, where in UE 5.2 there were still function calls and it cannot assume stuff can be nullptr or not.

On cooked builds, Asset could be not yet loaded.