### PR TITLE
Improvements for working with Input/Output pins in BP FlowNodes

### DIFF
--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -63,7 +63,8 @@ void UFlowNode::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEve
 	Super::PostEditChangeProperty(PropertyChangedEvent);
 
 	if (PropertyChangedEvent.Property
-		&& (PropertyChangedEvent.GetPropertyName() == GET_MEMBER_NAME_CHECKED(UFlowNode, InputPins) || PropertyChangedEvent.GetPropertyName() == GET_MEMBER_NAME_CHECKED(UFlowNode, OutputPins)))
+		&& (PropertyChangedEvent.GetPropertyName() == GET_MEMBER_NAME_CHECKED(UFlowNode, InputPins) || PropertyChangedEvent.GetPropertyName() == GET_MEMBER_NAME_CHECKED(UFlowNode, OutputPins)
+			|| PropertyChangedEvent.GetMemberPropertyName() == GET_MEMBER_NAME_CHECKED(UFlowNode, InputPins) || PropertyChangedEvent.GetMemberPropertyName() == GET_MEMBER_NAME_CHECKED(UFlowNode, OutputPins)))
 	{
 		OnReconstructionRequested.ExecuteIfBound();
 	}

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -141,32 +141,7 @@ void UFlowGraphNode::SubscribeToExternalChanges()
 	if (FlowNode)
 	{
 		FlowNode->OnReconstructionRequested.BindUObject(this, &UFlowGraphNode::OnExternalChange);
-
-		// blueprint nodes
-		if (FlowNode->GetClass()->ClassGeneratedBy && GEditor)
-		{
-			GEditor->OnBlueprintPreCompile().AddUObject(this, &UFlowGraphNode::OnBlueprintPreCompile);
-			GEditor->OnBlueprintCompiled().AddUObject(this, &UFlowGraphNode::OnBlueprintCompiled);
-		}
 	}
-}
-
-void UFlowGraphNode::OnBlueprintPreCompile(UBlueprint* Blueprint)
-{
-	if (Blueprint && Blueprint == FlowNode->GetClass()->ClassGeneratedBy)
-	{
-		bBlueprintCompilationPending = true;
-	}
-}
-
-void UFlowGraphNode::OnBlueprintCompiled()
-{
-	if (bBlueprintCompilationPending)
-	{
-		OnExternalChange();
-	}
-
-	bBlueprintCompilationPending = false;
 }
 
 void UFlowGraphNode::OnExternalChange()

--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -527,14 +527,16 @@ void SFlowGraphNode::CreateStandardPinWidget(UEdGraphPin* Pin)
 	{
 		if (Pin->Direction == EGPD_Input)
 		{
-			if (FlowGraphNode->GetFlowNode()->GetInputPins().Num() == 1 && Pin->PinName == UFlowNode::DefaultInputPin.PinName)
+			// Pin array can have pins with name None, which will not be created. We need to check if array have only one valid pin
+			if (ValidPinsCount(FlowGraphNode->GetFlowNode()->GetInputPins()) == 1 && Pin->PinName == UFlowNode::DefaultInputPin.PinName)
 			{
 				NewPin->SetShowLabel(false);
 			}
 		}
 		else
 		{
-			if (FlowGraphNode->GetFlowNode()->GetOutputPins().Num() == 1 && Pin->PinName == UFlowNode::DefaultOutputPin.PinName)
+			// Pin array can have pins with name None, which will not be created. We need to check if array have only one valid pin
+			if (ValidPinsCount(FlowGraphNode->GetFlowNode()->GetOutputPins()) == 1 && Pin->PinName == UFlowNode::DefaultOutputPin.PinName)
 			{
 				NewPin->SetShowLabel(false);
 			}
@@ -659,6 +661,20 @@ FReply SFlowGraphNode::OnAddFlowPin(const EEdGraphPinDirection Direction)
 	}
 
 	return FReply::Handled();
+}
+
+int32 SFlowGraphNode::ValidPinsCount(const TArray<FFlowPin>& Pins)
+{
+	int32 Count = 0;
+	for (const FFlowPin& Pin : Pins)
+	{
+		if (Pin.IsValid())
+		{
+			Count += 1;
+		}
+	}
+
+	return Count;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -60,10 +60,6 @@ public:
 
 private:
 	void SubscribeToExternalChanges();
-
-	void OnBlueprintPreCompile(UBlueprint* Blueprint);
-	void OnBlueprintCompiled();
-
 	void OnExternalChange();
 
 public:

--- a/Source/FlowEditor/Public/Graph/Widgets/SFlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Widgets/SFlowGraphNode.h
@@ -63,6 +63,9 @@ protected:
 	// Variant of SGraphNode::OnAddPin
 	virtual FReply OnAddFlowPin(const EEdGraphPinDirection Direction);
 
+private:
+	static int32 ValidPinsCount(const TArray<FFlowPin>& Pins);
+
 protected:
 	UFlowGraphNode* FlowGraphNode = nullptr;
 };


### PR DESCRIPTION
1. UFlowNode now also executes OnReconstructionRequested if pin info has been changed inside pin array (PinName, PinFriendlyName, PinToolTip).
2. Removed OnBlueprintPreCompile() and OnBlueprintCompiled() from UFlowGraphNode, because all possible node reconstructions, handled by these functions, now are triggered from UFlowNode::PostEditChangeProperty()
3. SFlowGraphNode now hides pin name only if there is one valid pin in array, not just Pins.Num() == 1.