### PR TITLE
Added check to prevent crash when deleting two or more node assets (if some of them are in undo history)

### DIFF
--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -422,7 +422,7 @@ void UFlowGraphSchema::GetCommentAction(FGraphActionMenuBuilder& ActionMenuBuild
 
 bool UFlowGraphSchema::IsFlowNodePlaceable(const UClass* Class)
 {
-	if (Class->HasAnyClassFlags(CLASS_Abstract | CLASS_NotPlaceable | CLASS_Deprecated))
+	if (Class == nullptr || Class->HasAnyClassFlags(CLASS_Abstract | CLASS_NotPlaceable | CLASS_Deprecated))
 	{
 		return false;
 	}


### PR DESCRIPTION
Steps to reproduce:
1. create two bp flow node assets
2. place one in any flow graph
3. delete placed node
4. delete created assets from step 1

The reason for this is that deleted graph node are stored in undo history, so there remains memory reference to node (and asset). And if user presses "force delete", Unreal treats deletion of both assets differently (compared to the case where there are no references), eventually setting their GeneratedClass to nullptr before broadcasting OnAssetRemoved delegate.  After that, UFlowGraphSchema::OnAssetRemoved triggers for every deleted asset separately (I tried to use AssetRegistry.Get().OnAssetsRemoved(), but it also broadcasts for every asset separately), and broadcasts OnNodeListChanged ... eventually UFlowGraphSchema::GetFlowNodeCategories will be called, and this is the place where first node will be already deleted from BlueprintFlowNodes array, but the second is not and the second already has GeneratedClass == nullptr.