### PR TITLE
Moves the Start or Load of the RootFlow to a virtual function.

### DIFF
--- a/Source/Flow/Private/FlowComponent.cpp
+++ b/Source/Flow/Private/FlowComponent.cpp
@@ -61,16 +61,21 @@ void UFlowComponent::RegisterWithFlowSubsystem()
 
 		FlowSubsystem->RegisterComponent(this);
 
-		if (RootFlow)
+		BeginRootFlow(bComponentLoadedFromSaveGame);
+	}
+}
+
+void UFlowComponent::BeginRootFlow(bool bComponentLoadedFromSaveGame)
+{
+	if (RootFlow)
+	{
+		if (bComponentLoadedFromSaveGame)
 		{
-			if (bComponentLoadedFromSaveGame)
-			{
-				LoadRootFlow();
-			}
-			else if (bAutoStartRootFlow)
-			{
-				StartRootFlow();
-			}
+			LoadRootFlow();
+		}
+		else if (bAutoStartRootFlow)
+		{
+			StartRootFlow();
 		}
 	}
 }

--- a/Source/Flow/Public/FlowComponent.h
+++ b/Source/Flow/Public/FlowComponent.h
@@ -84,7 +84,8 @@ public:
 protected:
 	void RegisterWithFlowSubsystem();
 	void UnregisterWithFlowSubsystem();
-	
+	virtual void BeginRootFlow(bool bComponentLoadedFromSaveGame);
+
 private:
 	UFUNCTION()
 	void OnRep_AddedIdentityTags();


### PR DESCRIPTION
    This allows projects are finer controll when implementing saving and loading.


____

E.g. in my project I overwrite the function in a way to _not_ call "LoadRootFlow()" in BeginPlay().
It is called as Part of my Persistence Subsystem