### PR TITLE
Restore SFlowGraphNode pin alignment to pre-FlowAddon settings

### DIFF
--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -923,9 +923,10 @@ void SFlowGraphNode::AddPin(const TSharedRef<SGraphPin>& PinToAdd)
 	if (PinToAdd->GetDirection() == EEdGraphPinDirection::EGPD_Input)
 	{
 		LeftNodeBox->AddSlot()
-			.HAlign(HAlign_Fill)
-			.VAlign(VAlign_Fill)
-			.FillHeight(1.0f)
+			.AutoHeight()
+			.HAlign(HAlign_Left)
+			.VAlign(VAlign_Center)
+			.Padding(Settings->GetInputPinPadding())
 			[
 				PinToAdd
 			];
@@ -934,9 +935,10 @@ void SFlowGraphNode::AddPin(const TSharedRef<SGraphPin>& PinToAdd)
 	else // Direction == EEdGraphPinDirection::EGPD_Output
 	{
 		RightNodeBox->AddSlot()
-			.HAlign(HAlign_Fill)
-			.VAlign(VAlign_Fill)
-			.FillHeight(1.0f)
+			.AutoHeight()
+			.HAlign(HAlign_Right)
+			.VAlign(VAlign_Center)
+			.Padding(Settings->GetOutputPinPadding())
 			[
 				PinToAdd
 			];


### PR DESCRIPTION
PR #202 added an override for SFlowGraphNode's AddPin function, causing pin alignment to be incorrect. This PR simply replaces the alignment and padding settings in AddPin with the original alignment settings in SGraphNode (default for pre-FlowAddons)

Alignment at present:
![Screenshot 2024-07-04 175249](https://github.com/MothCocoon/FlowGraph/assets/23412781/9c465b90-6a98-4b80-b704-e853aac45109)

Alignment and padding restored:
![Screenshot 2024-07-04 175121](https://github.com/MothCocoon/FlowGraph/assets/23412781/4587a481-e293-4b42-ba0b-3844e7357094)
