### PR TITLE
Change FlowEditor loading phase to "PreDefault" to fix corrupting FlowAssets when DefaultPawnClass for GameMode is set in C++ (as in Epic's templates)

### DIFF
--- a/Flow.uplugin
+++ b/Flow.uplugin
@@ -22,7 +22,7 @@
 		{
 			"Name" : "FlowEditor",
 			"Type" : "Editor",
-			"LoadingPhase" : "Default"
+			"LoadingPhase" : "PreDefault"
 		}
 	],
 	"Plugins": [


### PR DESCRIPTION
See detailed info for this bug here https://discord.com/channels/742802606874820619/1266207778398142464. 
In short, the problem is in this code:
```
AMyMode::AMyMode()
{
    // set default pawn class to our Blueprinted character
    static ConstructorHelpers::FClassFinder<APawn> PlayerPawnBPClass(TEXT("/Game/ThirdPerson/Blueprints/BP_ThirdPersonCharacter"));
    if (PlayerPawnBPClass.Class != NULL)
    {
        DefaultPawnClass = PlayerPawnBPClass.Class;
    }
}
```
If BP_ThirdPersonCharacter has Flow component and some FlowAsset as RootInstance, that asset will be corrupted (missing FlowGraph) after editor restart.


After changing LoadingPhase project was tested in DebugGame, Development and Shipping configurations - no issues was detected. But I am still not sure if I did not miss something.