### PR TITLE
Finish root flow instances without calling finish root flows externally.

### DIFF
--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -778,7 +778,17 @@ void UFlowAsset::FinishNode(UFlowNode* Node)
 			}
 			else
 			{
-				FinishFlow(EFlowFinishPolicy::Keep);
+				//If this is a root instance finish root flows else finish locally 
+				TSet<UFlowAsset*> RootFlowInstances = GetFlowSubsystem()->GetRootInstancesByOwner(Owner.Get());
+
+				if (RootFlowInstances.Contains(this))
+				{
+				    GetFlowSubsystem()->FinishRootFlow(Owner.Get(), TemplateAsset, EFlowFinishPolicy::Keep);
+				}
+				else
+				{
+				    FinishFlow(EFlowFinishPolicy::Keep);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This fix was proposed by Hojo in the discord server, I'm making the PR so that it can hopefully be merged into the main branch.
This solves the following issue:
1) Call Start Root Flow, flow runs
2) Flow runs and hits a Finish node
3) Call Start Root Flow again the same way
4) Warning: Attempted to start Root Flow for the same Owner again