### PR TITLE
Fix compile failure due to default C++ standard below 20

### DIFF
--- a/Source/FlowEditor/FlowEditor.Build.cs
+++ b/Source/FlowEditor/FlowEditor.Build.cs
@@ -6,6 +6,11 @@ public class FlowEditor : ModuleRules
 {
 	public FlowEditor(ReadOnlyTargetRules target) : base(target)
 	{
+		if(CppStandard is null || CppStandard != CppStandardVersion.Cpp20)
+		{
+			CppStandard = CppStandardVersion.Cpp20;
+		}
+
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
 		PublicDependencyModuleNames.AddRange(new[]


### PR DESCRIPTION
For some projects upgrading from older versions to UE5.2 or later, the default C++ standard used by the engine may not be C++20. This issue arises because the file ReviewComments.h contains syntax that is only supported in C++20:

```cpp 
bool bIsClosed : 1 = false;
```

This bitfield initialization will cause the module compilation to fail. Adding logic to ensure C++ standards in the module's Build.cs can solve this problem.