### PR TITLE
Fix Diff menu not using the FlowAsset of the current editor when several flow asset editors are opened

### DIFF
--- a/Source/FlowEditor/Public/Asset/FlowAssetToolbar.h
+++ b/Source/FlowEditor/Public/Asset/FlowAssetToolbar.h
@@ -8,6 +8,7 @@
 #include "FlowAsset.h"
 
 class FFlowAssetEditor;
+class UFlowAssetEditorContext;
 class UToolMenu;
 
 //////////////////////////////////////////////////////////////////////////
@@ -87,7 +88,7 @@ public:
 
 private:
 	void BuildAssetToolbar(UToolMenu* ToolbarMenu) const;
-	TSharedRef<SWidget> MakeDiffMenu() const;
+	static TSharedRef<SWidget> MakeDiffMenu(const UFlowAssetEditorContext* InContext);
 	
 	void BuildDebuggerToolbar(UToolMenu* ToolbarMenu) const;
 


### PR DESCRIPTION
The fix use the same code snippet that in "FBlueprintEditorToolbar" to bind the MakeDiffMenu to the toolbar.