### PR TITLE
Extension point to allow FlowGraphNode to do additional indexing.

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetIndexer.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetIndexer.cpp
@@ -120,6 +120,7 @@ void FFlowAssetIndexer::IndexGraph(const UFlowAsset* InFlowAsset, FSearchSeriali
 				{
 					Serializer.IndexProperty(Property, Value);
 				});
+				FlowGraphNode->AdditionalNodeIndexing(Serializer);
 				Serializer.EndIndexingObject();
 			}
 		}

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -4,6 +4,7 @@
 
 #include "EdGraph/EdGraphNode.h"
 #include "EdGraph/EdGraphPin.h"
+#include "SearchSerializer.h"
 #include "Templates/SubclassOf.h"
 
 #include "FlowTypes.h"
@@ -138,6 +139,9 @@ public:
 	bool IsContentPreloaded() const;
 
 	bool CanFocusViewport() const;
+
+	// Index properties that are not indexed by default
+	virtual void AdditionalNodeIndexing(FSearchSerializer& Serializer) const {}
 
 	// UEdGraphNode
 	virtual bool CanJumpToDefinition() const override;


### PR DESCRIPTION
Add a virtual function AdditionalNodeIndexing in FlowGraphNode to index property that are not handled by default