### PR TITLE
Initialize Data Pin Struct Values in order to remove errors

### DIFF
--- a/Source/Flow/Public/Types/FlowDataPinProperties.h
+++ b/Source/Flow/Public/Types/FlowDataPinProperties.h
@@ -263,7 +263,7 @@ struct FFlowDataPinOutputProperty_Vector : public FFlowDataPinProperty
 public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = DataPins)
-	FVector Value;
+	FVector Value = FVector::ZeroVector;
 
 public:
 
@@ -282,7 +282,7 @@ struct FFlowDataPinOutputProperty_Rotator : public FFlowDataPinProperty
 public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = DataPins)
-	FRotator Value;
+	FRotator Value = FRotator::ZeroRotator;
 
 public:
 

--- a/Source/Flow/Public/Types/FlowDataPinResults.h
+++ b/Source/Flow/Public/Types/FlowDataPinResults.h
@@ -234,7 +234,7 @@ struct FFlowDataPinResult_Vector : public FFlowDataPinResult
 public:
 
 	UPROPERTY(Transient, BlueprintReadWrite, Category = DataPins)
-	FVector Value;
+	FVector Value = FVector::ZeroVector;
 
 public:
 
@@ -253,7 +253,7 @@ struct FFlowDataPinResult_Rotator : public FFlowDataPinResult
 public:
 
 	UPROPERTY(Transient, BlueprintReadWrite, Category = DataPins)
-	FRotator Value;
+	FRotator Value = FRotator::ZeroRotator;
 
 public:
 

--- a/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
@@ -18,7 +18,7 @@ struct FFlowNodeDisplayStyleConfig
 
 public:
 	FFlowNodeDisplayStyleConfig()
-		: TitleColor()
+		: TitleColor(FLinearColor::White)
 	{
 	}
 


### PR DESCRIPTION
There were errors like this: "StructProperty FFlowDataPinResult_Rotator::Value is not initialized properly even though its struct probably has a custom default constructor. Module:Flow File:Public/Types/FlowDataPinResults.h". I initialized the problematic properties, so all the errors disappeared.