### PR TITLE
TObjectPtr Refactor

### DIFF
--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -106,7 +106,7 @@ void UFlowAsset::PostLoad()
 EDataValidationResult UFlowAsset::ValidateAsset(FFlowMessageLog& MessageLog)
 {
 	// validate nodes
-	for (const TPair<FGuid, UFlowNode*>& Node : Nodes)
+	for (const TPair<FGuid, UFlowNode*>& Node : ObjectPtrDecay(Nodes))
 	{
 		if (IsValid(Node.Value))
 		{
@@ -329,7 +329,7 @@ void UFlowAsset::HarvestNodeConnections()
 		}
 	}
 
-	for (const TPair<FGuid, UFlowNode*>& Pair : Nodes)
+	for (const TPair<FGuid, UFlowNode*>& Pair : ObjectPtrDecay(Nodes))
 	{
 		UFlowNode* FlowNode = Pair.Value;
 		TMap<FName, FConnectedPin> FoundConnections;
@@ -878,7 +878,7 @@ UFlowNode* UFlowAsset::GetDefaultEntryNode() const
 {
 	UFlowNode* FirstStartNode = nullptr;
 
-	for (const TPair<FGuid, UFlowNode*>& Node : Nodes)
+	for (const TPair<FGuid, UFlowNode*>& Node : ObjectPtrDecay(Nodes))
 	{
 		if (UFlowNode_Start* StartNode = Cast<UFlowNode_Start>(Node.Value))
 		{
@@ -946,7 +946,7 @@ UFlowNode_CustomInput* UFlowAsset::TryFindCustomInputNodeByEventName(const FName
 
 UFlowNode_CustomOutput* UFlowAsset::TryFindCustomOutputNodeByEventName(const FName& EventName) const
 {
-	for (const TPair<FGuid, UFlowNode*>& Node : Nodes)
+	for (const TPair<FGuid, UFlowNode*>& Node : ObjectPtrDecay(Nodes))
 	{
 		if (UFlowNode_CustomOutput* CustomOutput = Cast<UFlowNode_CustomOutput>(Node.Value))
 		{
@@ -966,7 +966,7 @@ TArray<FName> UFlowAsset::GatherCustomInputNodeEventNames() const
 	//  from the actual flow nodes
 	TArray<FName> Results;
 
-	for (const TPair<FGuid, UFlowNode*>& Node : Nodes)
+	for (const TPair<FGuid, UFlowNode*>& Node : ObjectPtrDecay(Nodes))
 	{
 		if (UFlowNode_CustomInput* CustomInput = Cast<UFlowNode_CustomInput>(Node.Value))
 		{
@@ -983,7 +983,7 @@ TArray<FName> UFlowAsset::GatherCustomOutputNodeEventNames() const
 	//  from the actual flow nodes
 	TArray<FName> Results;
 
-	for (const TPair<FGuid, UFlowNode*>& Node : Nodes)
+	for (const TPair<FGuid, UFlowNode*>& Node : ObjectPtrDecay(Nodes))
 	{
 		if (UFlowNode_CustomOutput* CustomOutput = Cast<UFlowNode_CustomOutput>(Node.Value))
 		{
@@ -1099,7 +1099,7 @@ void UFlowAsset::InitializeInstance(const TWeakObjectPtr<UObject> InOwner, UFlow
 	Owner = InOwner;
 	TemplateAsset = InTemplateAsset;
 
-	for (TPair<FGuid, UFlowNode*>& Node : Nodes)
+	for (TPair<FGuid, TObjectPtr<UFlowNode>>& Node : Nodes)
 	{
 		UFlowNode* NewNodeInstance = NewObject<UFlowNode>(this, Node.Value->GetClass(), NAME_None, RF_Transient, Node.Value, false, nullptr);
 		Node.Value = NewNodeInstance;
@@ -1118,7 +1118,7 @@ void UFlowAsset::InitializeInstance(const TWeakObjectPtr<UObject> InOwner, UFlow
 
 void UFlowAsset::DeinitializeInstance()
 {
-	for (const TPair<FGuid, UFlowNode*>& Node : Nodes)
+	for (const TPair<FGuid, UFlowNode*>& Node : ObjectPtrDecay(Nodes))
 	{
 		if (IsValid(Node.Value))
 		{

--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -126,7 +126,7 @@ void UFlowSubsystem::FinishRootFlow(UObject* Owner, UFlowAsset* TemplateAsset, c
 {
 	UFlowAsset* InstanceToFinish = nullptr;
 
-	for (TPair<UFlowAsset*, TWeakObjectPtr<UObject>>& RootInstance : RootInstances)
+	for (TPair<TObjectPtr<UFlowAsset>, TWeakObjectPtr<UObject>>& RootInstance : RootInstances)
 	{
 		if (Owner && Owner == RootInstance.Value.Get() && RootInstance.Key && RootInstance.Key->GetTemplateAsset() == TemplateAsset)
 		{
@@ -146,7 +146,7 @@ void UFlowSubsystem::FinishAllRootFlows(UObject* Owner, const EFlowFinishPolicy 
 {
 	TArray<UFlowAsset*> InstancesToFinish;
 
-	for (TPair<UFlowAsset*, TWeakObjectPtr<UObject>>& RootInstance : RootInstances)
+	for (TPair<TObjectPtr<UFlowAsset>, TWeakObjectPtr<UObject>>& RootInstance : RootInstances)
 	{
 		if (Owner && Owner == RootInstance.Value.Get() && RootInstance.Key)
 		{

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -159,7 +159,7 @@ protected:
 
 private:
 	UPROPERTY()
-	TMap<FGuid, UFlowNode*> Nodes;
+	TMap<FGuid, TObjectPtr<UFlowNode>> Nodes;
 
 #if WITH_EDITORONLY_DATA
 protected:
@@ -211,7 +211,7 @@ protected:
 #endif
 
 public:
-	const TMap<FGuid, UFlowNode*>& GetNodes() const { return Nodes; }
+	const TMap<FGuid, UFlowNode*>& GetNodes() const { return ObjectPtrDecay(Nodes); }
 	UFlowNode* GetNode(const FGuid& Guid) const { return Nodes.FindRef(Guid); }
 
 	template <class T>
@@ -290,7 +290,7 @@ protected:
 private:
 	// Original object holds references to instances
 	UPROPERTY(Transient)
-	TArray<UFlowAsset*> ActiveInstances;
+	TArray<TObjectPtr<UFlowAsset>> ActiveInstances;
 
 #if WITH_EDITORONLY_DATA
 	TWeakObjectPtr<UFlowAsset> InspectedInstance;
@@ -333,7 +333,7 @@ private:
 
 protected:
 	UPROPERTY()
-	UFlowAsset* TemplateAsset;
+	TObjectPtr<UFlowAsset> TemplateAsset;
 
 	// Object that spawned Root Flow instance, i.e. World Settings or Player Controller
 	// This pointer is passed to child instances: Flow Asset instances created by the SubGraph nodes
@@ -347,18 +347,18 @@ protected:
 
 	// Optional entry points to the graph, similar to blueprint Custom Events
 	UPROPERTY()
-	TSet<UFlowNode_CustomInput*> CustomInputNodes;
+	TSet<TObjectPtr<UFlowNode_CustomInput>> CustomInputNodes;
 
 	UPROPERTY()
-	TSet<UFlowNode*> PreloadedNodes;
+	TSet<TObjectPtr<UFlowNode>> PreloadedNodes;
 
 	// Nodes that have any work left, not marked as Finished yet
 	UPROPERTY()
-	TArray<UFlowNode*> ActiveNodes;
+	TArray<TObjectPtr<UFlowNode>> ActiveNodes;
 
 	// All nodes active in the past, done their work
 	UPROPERTY()
-	TArray<UFlowNode*> RecordedNodes;
+	TArray<TObjectPtr<UFlowNode>> RecordedNodes;
 
 	EFlowFinishPolicy FinishPolicy;
 

--- a/Source/Flow/Public/FlowComponent.h
+++ b/Source/Flow/Public/FlowComponent.h
@@ -177,7 +177,7 @@ private:
 public:
 	// Asset that might instantiated as "Root Flow" 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "RootFlow")
-	UFlowAsset* RootFlow;
+	TObjectPtr<UFlowAsset> RootFlow;
 
 	// If true, component will start Root Flow on Begin Play
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "RootFlow")

--- a/Source/Flow/Public/FlowSubsystem.h
+++ b/Source/Flow/Public/FlowSubsystem.h
@@ -39,15 +39,15 @@ public:
 private:
 	/* All asset templates with active instances */
 	UPROPERTY()
-	TArray<UFlowAsset*> InstancedTemplates;
+	TArray<TObjectPtr<UFlowAsset>> InstancedTemplates;
 
 	/* Assets instanced by object from another system, i.e. World Settings or Player Controller */
 	UPROPERTY()
-	TMap<UFlowAsset*, TWeakObjectPtr<UObject>> RootInstances;
+	TMap<TObjectPtr<UFlowAsset>, TWeakObjectPtr<UObject>> RootInstances;
 
 	/* Assets instanced by Sub Graph nodes */
 	UPROPERTY()
-	TMap<UFlowNode_SubGraph*, UFlowAsset*> InstancedSubFlows;
+	TMap<TObjectPtr<UFlowNode_SubGraph>, TObjectPtr<UFlowAsset>> InstancedSubFlows;
 
 #if WITH_EDITOR
 public:
@@ -60,7 +60,7 @@ public:
 	
 protected:
 	UPROPERTY()
-	UFlowSaveGame* LoadedSaveGame;
+	TObjectPtr<UFlowSaveGame> LoadedSaveGame;
 
 public:
 	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
@@ -112,7 +112,7 @@ public:
 
 	/* Returns assets instanced by Sub Graph nodes */
 	UFUNCTION(BlueprintPure, Category = "FlowSubsystem")
-	const TMap<UFlowNode_SubGraph*, UFlowAsset*>& GetInstancedSubFlows() const { return InstancedSubFlows; }
+	const TMap<UFlowNode_SubGraph*, UFlowAsset*>& GetInstancedSubFlows() const { return ObjectPtrDecay(InstancedSubFlows); }
 
 	virtual UWorld* GetWorld() const override;
 

--- a/Source/Flow/Public/FlowWorldSettings.h
+++ b/Source/Flow/Public/FlowWorldSettings.h
@@ -17,7 +17,7 @@ class FLOW_API AFlowWorldSettings : public AWorldSettings
 
 private:
 	UPROPERTY(BlueprintReadOnly, VisibleAnywhere, Category = "Flow", meta = (AllowPrivateAccess = "true"))
-	UFlowComponent* FlowComponent;
+	TObjectPtr<UFlowComponent> FlowComponent;
 
 public:
 	UFlowComponent* GetFlowComponent() const { return FlowComponent; }

--- a/Source/Flow/Public/LevelSequence/FlowLevelSequencePlayer.h
+++ b/Source/Flow/Public/LevelSequence/FlowLevelSequencePlayer.h
@@ -18,7 +18,7 @@ class FLOW_API UFlowLevelSequencePlayer : public ULevelSequencePlayer
 private:
 	// most likely this is a UFlowNode_PlayLevelSequence or its child
 	UPROPERTY()
-	UFlowNode* FlowEventReceiver;
+	TObjectPtr<UFlowNode> FlowEventReceiver;
 
 public:
 	// variant of ULevelSequencePlayer::CreateLevelSequencePlayer

--- a/Source/Flow/Public/MovieScene/MovieSceneFlowTrack.h
+++ b/Source/Flow/Public/MovieScene/MovieSceneFlowTrack.h
@@ -62,5 +62,5 @@ public:
 private:
 	/** The track's sections. */
 	UPROPERTY()
-	TArray<UMovieSceneSection*> Sections;
+	TArray<TObjectPtr<UMovieSceneSection>> Sections;
 };

--- a/Source/Flow/Public/Nodes/FlowNodeBase.h
+++ b/Source/Flow/Public/Nodes/FlowNodeBase.h
@@ -168,7 +168,7 @@ protected:
 protected:
 	// Flow Node AddOn attachments
 	UPROPERTY(BlueprintReadOnly, Instanced, Category = "FlowNode")
-	TArray<UFlowNodeAddOn*> AddOns;
+	TArray<TObjectPtr<UFlowNodeAddOn>> AddOns;
 
 protected:
 	// FlowNodes and AddOns may determine which AddOns are eligible to be their children
@@ -185,7 +185,7 @@ public:
 	virtual const TArray<UFlowNodeAddOn*>& GetFlowNodeAddOnChildren() const { return AddOns; }
 
 #if WITH_EDITOR
-	virtual TArray<UFlowNodeAddOn*>& GetFlowNodeAddOnChildrenByEditor() { return AddOns; }
+	virtual TArray<UFlowNodeAddOn*>& GetFlowNodeAddOnChildrenByEditor() { return MutableView(AddOns); }
 	EFlowAddOnAcceptResult CheckAcceptFlowNodeAddOnChild(const UFlowNodeAddOn* AddOnTemplate, const TArray<UFlowNodeAddOn*>& AdditionalAddOnsToAssumeAreChildren) const;
 #endif // WITH_EDITOR
 
@@ -272,7 +272,7 @@ public:
 // (some editor symbols exposed to enabled creation of non-editor tooling)
 
 	UPROPERTY()
-	UEdGraphNode* GraphNode;
+	TObjectPtr<UEdGraphNode> GraphNode;
 	
 #if WITH_EDITORONLY_DATA
 protected:

--- a/Source/Flow/Public/Nodes/FlowPin.h
+++ b/Source/Flow/Public/Nodes/FlowPin.h
@@ -55,7 +55,7 @@ protected:
 	// (C++ enums must bind by name using SubCategoryEnumName, due to a limitation with UE's UEnum discovery).
 	// This property is editor-only, but it is automatically copied into PinSubCategoryObject if the PinType matches (for runtime use).
 	UPROPERTY(EditAnywhere, Category = "FlowPin", meta = (EditCondition = "PinType == EFlowPinType::Enum", EditConditionHides))
-	UEnum* SubCategoryEnumClass = nullptr;
+	TObjectPtr<UEnum> SubCategoryEnumClass = nullptr;
 
 	// name of enum defined in c++ code, will take priority over asset from EnumType property
 	//  (this is a work-around because EnumClass cannot find C++ Enums, 

--- a/Source/Flow/Public/Nodes/World/FlowNode_CallOwnerFunction.h
+++ b/Source/Flow/Public/Nodes/World/FlowNode_CallOwnerFunction.h
@@ -76,5 +76,5 @@ protected:
 
 	// Parameter object to pass to the function when called
 	UPROPERTY(EditAnywhere, Category = "Call Owner", Instanced)
-	UFlowOwnerFunctionParams* Params;
+	TObjectPtr<UFlowOwnerFunctionParams> Params;
 };

--- a/Source/Flow/Public/Nodes/World/FlowNode_PlayLevelSequence.h
+++ b/Source/Flow/Public/Nodes/World/FlowNode_PlayLevelSequence.h
@@ -64,10 +64,10 @@ public:
 	
 protected:
 	UPROPERTY()
-	ULevelSequence* LoadedSequence;
+	TObjectPtr<ULevelSequence> LoadedSequence;
 
 	UPROPERTY()
-	UFlowLevelSequencePlayer* SequencePlayer;
+	TObjectPtr<UFlowLevelSequencePlayer> SequencePlayer;
 
 	// Play Rate set by the user in PlaybackSettings
 	float CachedPlayRate;

--- a/Source/Flow/Public/Types/FlowDataPinProperties.h
+++ b/Source/Flow/Public/Types/FlowDataPinProperties.h
@@ -228,7 +228,7 @@ public:
 
 	// Class for this enum
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = DataPins)
-	UEnum* EnumClass = nullptr;
+	TObjectPtr<UEnum> EnumClass = nullptr;
 
 #if WITH_EDITORONLY_DATA
 	// name of enum defined in c++ code, will take priority over asset from EnumType property

--- a/Source/Flow/Public/Types/FlowDataPinResults.h
+++ b/Source/Flow/Public/Types/FlowDataPinResults.h
@@ -177,7 +177,7 @@ public:
 
 	// Class for this enum
 	UPROPERTY(Transient, BlueprintReadWrite, Category = DataPins)
-	UEnum* EnumClass = nullptr;
+	TObjectPtr<UEnum> EnumClass = nullptr;
 
 public:
 

--- a/Source/Flow/Public/Types/FlowInjectComponentsManager.h
+++ b/Source/Flow/Public/Types/FlowInjectComponentsManager.h
@@ -63,5 +63,5 @@ public:
 
 	// Map of spawned components (if we are cleaning up)
 	UPROPERTY(Transient)
-	TMap<AActor*, FFlowComponentInstances> ActorToComponentsMap;
+	TMap<TObjectPtr<AActor>, FFlowComponentInstances> ActorToComponentsMap;
 };

--- a/Source/FlowEditor/Private/DetailCustomizations/FlowActorOwnerComponentFilters.cpp
+++ b/Source/FlowEditor/Private/DetailCustomizations/FlowActorOwnerComponentFilters.cpp
@@ -81,11 +81,11 @@ void FFlowActorOwnerComponentFilters::BuildClassFilters(const FProperty& Compone
 
 	// Account for the allowed classes specified in the property metadata
 	const FString& AllowedClassesFilterString = ComponentNameProperty.GetMetaData(NAME_AllowedClasses);
-	ParseClassFilters(AllowedClassesFilterString, AllowedComponentClassFilters);
+	ParseClassFilters(AllowedClassesFilterString, MutableView(AllowedComponentClassFilters));
 
 	// Account for disallowed classes specified in the property metadata
 	const FString& DisallowedClassesFilterString = ComponentNameProperty.GetMetaData(NAME_DisallowedClasses);
-	ParseClassFilters(DisallowedClassesFilterString, DisallowedComponentClassFilters);
+	ParseClassFilters(DisallowedClassesFilterString, MutableView(DisallowedComponentClassFilters));
 }
 
 void FFlowActorOwnerComponentFilters::BuildInterfaceFilters(const FProperty& ComponentNameProperty)
@@ -109,7 +109,7 @@ void FFlowActorOwnerComponentFilters::BuildInterfaceFilters(const FProperty& Com
 
 	// MustImplement interface(s)
 	const FString& MustImplementInterfacesFilterString = ComponentNameProperty.GetMetaData(NAME_MustImplement);
-	ParseInterfaceFilters(MustImplementInterfacesFilterString, RequiredInterfaceFilters);
+	ParseInterfaceFilters(MustImplementInterfacesFilterString, MutableView(RequiredInterfaceFilters));
 }
 
 bool FFlowActorOwnerComponentFilters::IsFilteredComponent(const UActorComponent& Component) const

--- a/Source/FlowEditor/Private/DetailCustomizations/FlowActorOwnerComponentFilters.h
+++ b/Source/FlowEditor/Private/DetailCustomizations/FlowActorOwnerComponentFilters.h
@@ -35,15 +35,15 @@ protected:
 #if WITH_EDITORONLY_DATA
 	// Classes that can be used with this property
 	UPROPERTY(Transient)
-	TArray<const UClass*> AllowedComponentClassFilters;
+	TArray<TObjectPtr<const UClass>> AllowedComponentClassFilters;
 
 	// Classes that can NOT be used with this property
 	UPROPERTY(Transient)
-	TArray<const UClass*> DisallowedComponentClassFilters;
+	TArray<TObjectPtr<const UClass>> DisallowedComponentClassFilters;
 
 	// Must implement (all) interface(s)
 	UPROPERTY(Transient)
-	TArray<const UClass*> RequiredInterfaceFilters;
+	TArray<TObjectPtr<const UClass>> RequiredInterfaceFilters;
 
 	// Has BuildClassFiltersFromMetadata been called?
 	UPROPERTY(Transient)

--- a/Source/FlowEditor/Public/Asset/FlowImportUtils.h
+++ b/Source/FlowEditor/Public/Asset/FlowImportUtils.h
@@ -15,7 +15,7 @@ struct FLOWEDITOR_API FImportedGraphNode
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	UEdGraphNode* SourceGraphNode;
+	TObjectPtr<UEdGraphNode> SourceGraphNode;
 
 	TMultiMap<FName, FConnectedPin> Incoming;
 	TMultiMap<FName, FConnectedPin> Outgoing;

--- a/Source/FlowEditor/Public/Graph/FlowGraphSchema_Actions.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSchema_Actions.h
@@ -15,7 +15,7 @@ struct FLOWEDITOR_API FFlowGraphSchemaAction_NewNode : public FEdGraphSchemaActi
 	GENERATED_USTRUCT_BODY()
 
 	UPROPERTY()
-	class UClass* NodeClass;
+	TObjectPtr<class UClass> NodeClass;
 
 	static FName StaticGetTypeId()
 	{

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -34,7 +34,7 @@ class FLOWEDITOR_API UFlowGraphNode : public UEdGraphNode
 private:
 	// The FlowNode or FlowNodeAddOn runtime instance that is being edited by this UFlowGraphNode
 	UPROPERTY(Instanced)
-	UFlowNodeBase* NodeInstance;
+	TObjectPtr<UFlowNodeBase> NodeInstance;
 
 	bool bBlueprintCompilationPending;
 	bool bIsReconstructingNode;


### PR DESCRIPTION
Refactors various headers to utilize TObjectPtr for raw UPROPERTY pointers. Some projects might have TObjectPtr enforcement enabled starting from 5.5, and this prevents plugin from compiling.