### PR TITLE
Replace SFlowGraphNode style with default K2Node style.

### DIFF
--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -208,6 +208,12 @@ void SFlowGraphNode::UpdateGraphNode()
 
 	const TSharedRef<SOverlay> DefaultTitleAreaWidget = SNew(SOverlay)
 		+ SOverlay::Slot()
+		[
+			SNew(SImage)
+			.Image( FAppStyle::GetBrush("Graph.Node.TitleGloss") )
+			.ColorAndOpacity( this, &SGraphNode::GetNodeTitleIconColor )
+		]
+		+ SOverlay::Slot()
 		.HAlign(HAlign_Fill)
 		.VAlign(VAlign_Center)
 		[
@@ -216,7 +222,7 @@ void SFlowGraphNode::UpdateGraphNode()
 			.HAlign(HAlign_Fill)
 			[
 				SNew(SBorder)
-				.BorderImage(FFlowEditorStyle::GetBrush("Flow.Node.Title"))
+				.BorderImage(FAppStyle::GetBrush("Graph.Node.ColorSpill"))
 				// The extra margin on the right is for making the color spill stretch well past the node title
 				.Padding(FMargin(10, 5, 30, 3))
 				.BorderBackgroundColor(this, &SFlowGraphNode::GetBorderBackgroundColor)
@@ -246,6 +252,26 @@ void SFlowGraphNode::UpdateGraphNode()
 								]
 						]
 				]
+			]
+			+ SHorizontalBox::Slot()
+			.HAlign(HAlign_Right)
+			.VAlign(VAlign_Center)
+			.Padding(0, 0, 5, 0)
+			.AutoWidth()
+			[
+				CreateTitleRightWidget()
+			]
+		]
+		+SOverlay::Slot()
+		.VAlign(VAlign_Top)
+		[
+			SNew(SBorder)
+			.Visibility(EVisibility::HitTestInvisible)			
+			.BorderImage( FAppStyle::GetBrush( "Graph.Node.TitleHighlight" ) )
+			.BorderBackgroundColor( this, &SGraphNode::GetNodeTitleIconColor )
+			[
+				SNew(SSpacer)
+				.Size(FVector2D(20,20))
 			]
 		];
 
@@ -629,7 +655,7 @@ TSharedRef<SWidget> SFlowGraphNode::CreateNodeContentArea()
 
 const FSlateBrush* SFlowGraphNode::GetNodeBodyBrush() const
 {
-	return FFlowEditorStyle::GetBrush("Flow.Node.Body");
+	return FAppStyle::GetBrush("Graph.Node.Body");
 }
 
 FSlateColor SFlowGraphNode::GetNodeTitleColor() const


### PR DESCRIPTION
This was needed because style plugins like "Darker Nodes" couldn't affect these nodes.

(cherry picked from commit 0b502276de03e8dac2b73c5e86dabce76f37a978)