### PR TITLE
Check FlowNode is active before TriggerOutput

### DIFF
--- a/Source/Flow/Private/Nodes/FlowNode.cpp
+++ b/Source/Flow/Private/Nodes/FlowNode.cpp
@@ -863,6 +863,13 @@ void UFlowNode::TriggerFirstOutput(const bool bFinish)
 
 void UFlowNode::TriggerOutput(const FName PinName, const bool bFinish /*= false*/, const EFlowPinActivationType ActivationType /*= Default*/)
 {
+	if (ActivationState == EFlowNodeState::Completed || ActivationState == EFlowNodeState::Aborted)
+	{
+		// do not trigger output if node is already finished or aborted
+		LogError(TEXT("Trying to TriggerOutput after finished or aborted"));
+		return;
+	}
+
 	// clean up node, if needed
 	if (bFinish)
 	{


### PR DESCRIPTION
If FlowNode **already finished or aborted**, we:
**1. report an error** (in this way, we don’t hide other problems such as not cleanup properly)
**2. then return** (we do not trigger output if node is finished or aborted)