### PR TITLE
Graph refresh system cleanup

### DIFF
--- a/Source/Flow/Private/AddOns/FlowNodeAddOn.cpp
+++ b/Source/Flow/Private/AddOns/FlowNodeAddOn.cpp
@@ -1,6 +1,8 @@
 // Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
 
 #include "AddOns/FlowNodeAddOn.h"
+
+#include "FlowLogChannels.h"
 #include "Nodes/FlowNode.h"
 
 #include "Misc/RuntimeErrors.h"
@@ -105,17 +107,34 @@ void UFlowNodeAddOn::CacheFlowNode()
 }
 
 #if WITH_EDITOR
-TArray<FFlowPin> UFlowNodeAddOn::GetContextInputs() const
+TArray<FFlowPin> UFlowNodeAddOn::GetPinsForContext(const TArray<FFlowPin>& Context) const
 {
 	TArray<FFlowPin> ContextPins = Super::GetContextInputs();
-	ContextPins.Append(InputPins);
+
+	ContextPins.Reserve(ContextPins.Num() + Context.Num());
+	
+	for (const FFlowPin& InputPin : Context)
+	{
+		if (InputPin.IsValid())
+		{
+			ContextPins.Add(InputPin);
+		}
+		else
+		{
+			UE_LOG(LogFlow, Warning, TEXT("Addon %s has invalid pins (name: None), you should clean these up."), *GetName());
+		}
+	}
+
 	return ContextPins;
+}
+
+TArray<FFlowPin> UFlowNodeAddOn::GetContextInputs() const
+{
+	return GetPinsForContext(InputPins);
 }
 
 TArray<FFlowPin> UFlowNodeAddOn::GetContextOutputs() const
 {
-	TArray<FFlowPin> ContextPins = Super::GetContextOutputs();
-	ContextPins.Append(OutputPins);
-	return ContextPins;
+	return GetPinsForContext(OutputPins);
 }
 #endif // WITH_EDITOR

--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -331,30 +331,49 @@ void UFlowAsset::UnregisterNode(const FGuid& NodeGuid)
 	MarkPackageDirty();
 }
 
-void UFlowAsset::HarvestNodeConnections()
+void UFlowAsset::HarvestNodeConnections(UFlowNode* TargetNode)
 {
-	TMap<FName, FConnectedPin> Connections;
-	bool bGraphDirty = false;
+	TArray<UFlowNode*> TargetNodes;
 
-	// last moment to remove invalid nodes
-	for (auto NodeIt = Nodes.CreateIterator(); NodeIt; ++NodeIt)
+	if (IsValid(TargetNode))
 	{
-		const TPair<FGuid, UFlowNode*>& Pair = *NodeIt;
-		if (Pair.Value == nullptr)
+		TargetNodes.Add(TargetNode);
+	}
+	else
+	{
+		for (const TPair<FGuid, UFlowNode*>& Pair : ObjectPtrDecay(Nodes))
+		{
+			TargetNodes.Add(Pair.Value);
+		}
+	}
+	
+	// Remove any invalid nodes
+	for (auto NodeIt = TargetNodes.CreateIterator(); NodeIt; ++NodeIt)
+	{
+		if (*NodeIt == nullptr)
 		{
 			NodeIt.RemoveCurrent();
-			bGraphDirty = true;
+			Modify();
 		}
 	}
 
-	for (const TPair<FGuid, UFlowNode*>& Pair : ObjectPtrDecay(Nodes))
+	bool bAnyNodeDirty = false;
+	
+	for (UFlowNode* FlowNode : TargetNodes)
 	{
-		UFlowNode* FlowNode = Pair.Value;
+		bool bNodeDirty = false;
+
 		TMap<FName, FConnectedPin> FoundConnections;
 		const TArray<UEdGraphPin*>& GraphNodePins = FlowNode->GetGraphNode()->Pins;
 
 		for (const UEdGraphPin* ThisPin : GraphNodePins)
 		{
+			// Do not harvest orphaned pins
+			if (ThisPin->bOrphanedPin)
+			{
+			//	continue;
+			}
+			
 			const bool bIsExecPin = FFlowPin::IsExecPinCategory(ThisPin->PinType.PinCategory);
 			const bool bIsDataPin = FFlowPin::IsDataPinCategory(ThisPin->PinType.PinCategory);
 			const bool bIsOutputPin = (ThisPin->Direction == EGPD_Output);
@@ -383,13 +402,13 @@ void UFlowAsset::HarvestNodeConnections()
 
 		// This check exists to ensure that we don't mark graph dirty, if none of connections changed
 		// Optimization: we need check it only until the first node would be marked dirty, as this already marks Flow Asset package dirty
-		if (bGraphDirty == false)
+		if (bAnyNodeDirty == false)
 		{
 			const TMap<FName, FConnectedPin>& OldConnections = FlowNode->Connections;
 
 			if (FoundConnections.Num() != OldConnections.Num())
 			{
-				bGraphDirty = true;
+				bNodeDirty = true;
 			}
 			else
 			{
@@ -399,20 +418,20 @@ void UFlowAsset::HarvestNodeConnections()
 					{
 						if (FoundConnection.Value != *OldConnection)
 						{
-							bGraphDirty = true;
+							bNodeDirty = true;
 							break;
 						}
 					}
 					else
 					{
-						bGraphDirty = true;
+						bNodeDirty = true;
 						break;
 					}
 				}
 			}
 		}
 
-		if (bGraphDirty)
+		if (bNodeDirty || bAnyNodeDirty)
 		{
 			FlowNode->SetFlags(RF_Transactional);
 			FlowNode->Modify();

--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -337,10 +337,12 @@ void UFlowAsset::HarvestNodeConnections(UFlowNode* TargetNode)
 
 	if (IsValid(TargetNode))
 	{
+		TargetNodes.Reserve(1);
 		TargetNodes.Add(TargetNode);
 	}
 	else
 	{
+		TargetNodes.Reserve(Nodes.Num());
 		for (const TPair<FGuid, UFlowNode*>& Pair : ObjectPtrDecay(Nodes))
 		{
 			TargetNodes.Add(Pair.Value);
@@ -367,13 +369,7 @@ void UFlowAsset::HarvestNodeConnections(UFlowNode* TargetNode)
 		const TArray<UEdGraphPin*>& GraphNodePins = FlowNode->GetGraphNode()->Pins;
 
 		for (const UEdGraphPin* ThisPin : GraphNodePins)
-		{
-			// Do not harvest orphaned pins
-			if (ThisPin->bOrphanedPin)
-			{
-			//	continue;
-			}
-			
+		{			
 			const bool bIsExecPin = FFlowPin::IsExecPinCategory(ThisPin->PinType.PinCategory);
 			const bool bIsDataPin = FFlowPin::IsDataPinCategory(ThisPin->PinType.PinCategory);
 			const bool bIsOutputPin = (ThisPin->Direction == EGPD_Output);
@@ -441,7 +437,7 @@ void UFlowAsset::HarvestNodeConnections(UFlowNode* TargetNode)
 		}
 	}
 
-	// NOTE (gtaylor) @mothdoctor, do we need to do anything with bGraphDirty here?  
+	// NOTE (gtaylor) @mothdoctor, do we need to do anything with bGraphDirty [renamed by @HomerJohnston to bAnyNodeDirty] here?  
 	// It's scope seems like we wanted to do something at this point.
 }
 

--- a/Source/Flow/Public/AddOns/FlowNodeAddOn.h
+++ b/Source/Flow/Public/AddOns/FlowNodeAddOn.h
@@ -78,4 +78,8 @@ public:
 
 protected:
 	void CacheFlowNode();
+
+#if WITH_EDITOR
+	TArray<FFlowPin> GetPinsForContext(const TArray<FFlowPin>& Context) const;
+#endif
 };

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -190,8 +190,8 @@ public:
 	void RegisterNode(const FGuid& NewGuid, UFlowNode* NewNode);
 	void UnregisterNode(const FGuid& NodeGuid);
 
-	// Processes all nodes and creates map of all pin connections
-	void HarvestNodeConnections();
+	// Processes nodes and updates pin connections from the graph to the UFlowNode (processes all nodes in the graph if passed nullptr)
+	void HarvestNodeConnections(UFlowNode* TargetNode = nullptr);
 
 	// Updates the auto-generated pins and bindings for a given FlowNode,
 	// returns true if any changes were made.

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -190,7 +190,7 @@ public:
 	void RegisterNode(const FGuid& NewGuid, UFlowNode* NewNode);
 	void UnregisterNode(const FGuid& NodeGuid);
 
-	// Processes all nodes and creates map of all pin connections
+	// Processes nodes and updates pin connections from the graph to the UFlowNode (processes all nodes in the graph if passed nullptr)
 	void HarvestNodeConnections(UFlowNode* TargetNode = nullptr);
 
 	// Updates the auto-generated pins and bindings for a given FlowNode,

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -191,7 +191,7 @@ public:
 	void UnregisterNode(const FGuid& NodeGuid);
 
 	// Processes all nodes and creates map of all pin connections
-	void HarvestNodeConnections();
+	void HarvestNodeConnections(UFlowNode* TargetNode = nullptr);
 
 	// Updates the auto-generated pins and bindings for a given FlowNode,
 	// returns true if any changes were made.

--- a/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
@@ -77,10 +77,6 @@ void FFlowAssetEditor::HandleUndoTransaction()
 
 void FFlowAssetEditor::NotifyPostChange(const FPropertyChangedEvent& PropertyChangedEvent, FProperty* PropertyThatChanged)
 {
-	if (PropertyChangedEvent.ChangeType != EPropertyChangeType::Interactive)
-	{
-		GraphEditor->NotifyGraphChanged();
-	}
 }
 
 FName FFlowAssetEditor::GetToolkitFName() const

--- a/Source/FlowEditor/Private/FlowEditorCommands.cpp
+++ b/Source/FlowEditor/Private/FlowEditorCommands.cpp
@@ -34,7 +34,7 @@ FFlowGraphCommands::FFlowGraphCommands()
 
 void FFlowGraphCommands::RegisterCommands()
 {
-	UI_COMMAND(RefreshContextPins, "Refresh context pins", "Refresh pins generated from the context asset", EUserInterfaceActionType::Button, FInputChord());
+	UI_COMMAND(ReconstructNode, "Reconstruct node", "Reconstruct this node", EUserInterfaceActionType::Button, FInputChord());
 
 	UI_COMMAND(AddInput, "Add Input", "Adds an input to the node", EUserInterfaceActionType::Button, FInputChord());
 	UI_COMMAND(AddOutput, "Add Output", "Adds an output to the node", EUserInterfaceActionType::Button, FInputChord());

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
@@ -11,6 +11,7 @@
 #include "Nodes/Route/FlowNode_SubGraph.h"
 
 #include "EdGraphUtilities.h"
+#include "GraphEditAction.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Framework/Commands/GenericCommands.h"
 #include "GraphEditorActions.h"
@@ -104,9 +105,9 @@ void SFlowGraphEditor::BindGraphCommands()
 	                               FCanExecuteAction::CreateSP(this, &SFlowGraphEditor::CanDuplicateNodes));
 
 	// Pin commands
-	CommandList->MapAction(FlowGraphCommands.RefreshContextPins,
-	                               FExecuteAction::CreateSP(this, &SFlowGraphEditor::RefreshContextPins),
-	                               FCanExecuteAction::CreateSP(this, &SFlowGraphEditor::CanRefreshContextPins));
+	CommandList->MapAction(FlowGraphCommands.ReconstructNode,
+	                               FExecuteAction::CreateSP(this, &SFlowGraphEditor::ReconstructNode),
+	                               FCanExecuteAction::CreateSP(this, &SFlowGraphEditor::CanReconstructNode));
 
 	CommandList->MapAction(FlowGraphCommands.AddInput,
 	                               FExecuteAction::CreateSP(this, &SFlowGraphEditor::AddInput),
@@ -985,15 +986,15 @@ void SFlowGraphEditor::OnNodeTitleCommitted(const FText& NewText, ETextCommit::T
 	}
 }
 
-void SFlowGraphEditor::RefreshContextPins() const
+void SFlowGraphEditor::ReconstructNode() const
 {
 	for (UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		SelectedNode->RefreshContextPins(true);
+		SelectedNode->ReconstructNode();
 	}
 }
 
-bool SFlowGraphEditor::CanRefreshContextPins() const
+bool SFlowGraphEditor::CanReconstructNode() const
 {
 	if (CanEdit() && GetSelectedFlowNodes().Num() == 1)
 	{

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
@@ -11,6 +11,7 @@
 #include "Nodes/Route/FlowNode_SubGraph.h"
 
 #include "EdGraphUtilities.h"
+#include "GraphEditAction.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Framework/Commands/GenericCommands.h"
 #include "GraphEditorActions.h"
@@ -104,9 +105,9 @@ void SFlowGraphEditor::BindGraphCommands()
 	                               FCanExecuteAction::CreateSP(this, &SFlowGraphEditor::CanDuplicateNodes));
 
 	// Pin commands
-	CommandList->MapAction(FlowGraphCommands.RefreshContextPins,
-	                               FExecuteAction::CreateSP(this, &SFlowGraphEditor::RefreshContextPins),
-	                               FCanExecuteAction::CreateSP(this, &SFlowGraphEditor::CanRefreshContextPins));
+	CommandList->MapAction(FlowGraphCommands.ReconstructNode,
+	                               FExecuteAction::CreateSP(this, &SFlowGraphEditor::ReconstructNode),
+	                               FCanExecuteAction::CreateSP(this, &SFlowGraphEditor::CanReconstructNode));
 
 	CommandList->MapAction(FlowGraphCommands.AddInput,
 	                               FExecuteAction::CreateSP(this, &SFlowGraphEditor::AddInput),
@@ -985,7 +986,7 @@ void SFlowGraphEditor::OnNodeTitleCommitted(const FText& NewText, ETextCommit::T
 	}
 }
 
-void SFlowGraphEditor::RefreshContextPins() const
+void SFlowGraphEditor::ReconstructNode() const
 {
 	for (UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
@@ -993,7 +994,7 @@ void SFlowGraphEditor::RefreshContextPins() const
 	}
 }
 
-bool SFlowGraphEditor::CanRefreshContextPins() const
+bool SFlowGraphEditor::CanReconstructNode() const
 {
 	if (CanEdit() && GetSelectedFlowNodes().Num() == 1)
 	{

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
@@ -989,7 +989,7 @@ void SFlowGraphEditor::RefreshContextPins() const
 {
 	for (UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		SelectedNode->RefreshContextPins(true);
+		SelectedNode->ReconstructNode();
 	}
 }
 

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -570,18 +570,17 @@ const FPinConnectionResponse UFlowGraphSchema::CanMergeNodes(const UEdGraphNode*
 
 bool UFlowGraphSchema::TryCreateConnection(UEdGraphPin* PinA, UEdGraphPin* PinB) const
 {
-	const bool bModified = UEdGraphSchema::TryCreateConnection(PinA, PinB);
-
+	bool bModified = UEdGraphSchema::TryCreateConnection(PinA, PinB);
+	
 	if (bModified)
 	{
-		UEdGraphNode* PinANode = PinA->GetOwningNode();
-		PinANode->ReconstructNode();
+		UFlowGraphNode* GraphNodeA = Cast<UFlowGraphNode>(PinA->GetOwningNode());
+		UFlowGraphNode* GraphNodeB = Cast<UFlowGraphNode>(PinB->GetOwningNode());
 
-		UEdGraphNode* PinBNode = PinB->GetOwningNode();
-		PinBNode->ReconstructNode();
-		
-		PinA->GetOwningNode()->GetGraph()->NotifyNodeChanged(PinANode);
-		PinA->GetOwningNode()->GetGraph()->NotifyNodeChanged(PinBNode);
+		UEdGraph* Graph = GraphNodeA->GetGraph();
+
+		Graph->NotifyNodeChanged(GraphNodeA);
+		Graph->NotifyNodeChanged(GraphNodeB);
 	}
 
 	return bModified;
@@ -764,13 +763,12 @@ void UFlowGraphSchema::BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNoti
 {
 	const FScopedTransaction Transaction(LOCTEXT("GraphEd_BreakPinLinks", "Break Pin Links"));
 
-	Super::BreakPinLinks(TargetPin, bSendsNodeNotification);
+	TArray<UEdGraphPin*> CachedLinkedTo = TargetPin.LinkedTo;
 
-	// Cache the owning node because calling Super::BreakPinLinks might release the pointer
-	// to the pin owning node as a side effect of notify graph changed events. 
 	UFlowGraphNode* OwningFlowGraphNode = Cast<UFlowGraphNode>(TargetPin.GetOwningNodeUnchecked());
+	UEdGraph* EdGraph = (OwningFlowGraphNode) ? OwningFlowGraphNode->GetGraph() : nullptr;
 
-	// NOTE (gtaylor) It is possible for OwningFlowGraphNode to be null if the TargetPin has been orphaned.
+	Super::BreakPinLinks(TargetPin, bSendsNodeNotification);
 
 	if (TargetPin.bOrphanedPin)
 	{
@@ -782,10 +780,23 @@ void UFlowGraphSchema::BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNoti
 	}
 	else if (bSendsNodeNotification)
 	{
-		UEdGraph* EdGraph = (OwningFlowGraphNode) ? OwningFlowGraphNode->GetGraph() : nullptr;
 		if (IsValid(EdGraph))
 		{
 			EdGraph->NotifyNodeChanged(OwningFlowGraphNode);
+		}
+	}
+
+	for (UEdGraphPin* OtherPin : CachedLinkedTo)
+	{
+		UFlowGraphNode* OtherOwningFlowGraphNode = Cast<UFlowGraphNode>(OtherPin->GetOwningNodeUnchecked());
+		
+		if (OtherPin->bOrphanedPin)
+		{
+			 OtherOwningFlowGraphNode->RemoveOrphanedPin(OtherPin);
+		}
+		else if (bSendsNodeNotification)
+		{
+			EdGraph->NotifyNodeChanged(OtherOwningFlowGraphNode);
 		}
 	}
 }

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -774,7 +774,7 @@ void UFlowGraphSchema::BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNoti
 	{
 		if (OwningFlowGraphNode)
 		{
-			// this calls NotifyGraphChanged()
+			// this calls NotifyNodeChanged()
 			OwningFlowGraphNode->RemoveOrphanedPin(&TargetPin);
 		}
 	}
@@ -792,6 +792,7 @@ void UFlowGraphSchema::BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNoti
 		
 		if (OtherPin->bOrphanedPin)
 		{
+			// this calls NotifyNodeChanged()
 			 OtherOwningFlowGraphNode->RemoveOrphanedPin(OtherPin);
 		}
 		else if (bSendsNodeNotification)

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -574,13 +574,13 @@ bool UFlowGraphSchema::TryCreateConnection(UEdGraphPin* PinA, UEdGraphPin* PinB)
 	
 	if (bModified)
 	{
-		UFlowGraphNode* GraphNodeA = Cast<UFlowGraphNode>(PinA->GetOwningNode());
-		UFlowGraphNode* GraphNodeB = Cast<UFlowGraphNode>(PinB->GetOwningNode());
+		UFlowGraphNode* FlowGraphNodeA = Cast<UFlowGraphNode>(PinA->GetOwningNode());
+		UFlowGraphNode* FlowGraphNodeB = Cast<UFlowGraphNode>(PinB->GetOwningNode());
 
-		UEdGraph* Graph = GraphNodeA->GetGraph();
+		UEdGraph* EdGraph = FlowGraphNodeA->GetGraph();
 
-		Graph->NotifyNodeChanged(GraphNodeA);
-		Graph->NotifyNodeChanged(GraphNodeB);
+		EdGraph->NotifyNodeChanged(FlowGraphNodeA);
+		EdGraph->NotifyNodeChanged(FlowGraphNodeB);
 	}
 
 	return bModified;

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -574,7 +574,14 @@ bool UFlowGraphSchema::TryCreateConnection(UEdGraphPin* PinA, UEdGraphPin* PinB)
 
 	if (bModified)
 	{
-		PinA->GetOwningNode()->GetGraph()->NotifyGraphChanged();
+		UEdGraphNode* PinANode = PinA->GetOwningNode();
+		PinANode->ReconstructNode();
+
+		UEdGraphNode* PinBNode = PinB->GetOwningNode();
+		PinBNode->ReconstructNode();
+		
+		PinA->GetOwningNode()->GetGraph()->NotifyNodeChanged(PinANode);
+		PinA->GetOwningNode()->GetGraph()->NotifyNodeChanged(PinBNode);
 	}
 
 	return bModified;
@@ -751,12 +758,6 @@ bool UFlowGraphSchema::IsTitleBarPin(const UEdGraphPin& Pin) const
 void UFlowGraphSchema::BreakNodeLinks(UEdGraphNode& TargetNode) const
 {
 	Super::BreakNodeLinks(TargetNode);
-
-	UEdGraph* EdGraph = TargetNode.GetGraph();
-	if (IsValid(EdGraph))
-	{
-		EdGraph->NotifyGraphChanged();
-	}
 }
 
 void UFlowGraphSchema::BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNotification) const
@@ -784,7 +785,7 @@ void UFlowGraphSchema::BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNoti
 		UEdGraph* EdGraph = (OwningFlowGraphNode) ? OwningFlowGraphNode->GetGraph() : nullptr;
 		if (IsValid(EdGraph))
 		{
-			EdGraph->NotifyGraphChanged();
+			EdGraph->NotifyNodeChanged(OwningFlowGraphNode);
 		}
 	}
 }

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema_Actions.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema_Actions.cpp
@@ -69,7 +69,7 @@ UFlowGraphNode* FFlowGraphSchemaAction_NewNode::CreateNode(UEdGraph* ParentGraph
 	NewGraphNode->SetNodeTemplate(FlowNode);
 
 	// create pins and connections
-	NewGraphNode->AllocateDefaultPins();
+	NewGraphNode->ReconstructNode();
 	NewGraphNode->AutowireNewNode(FromPin);
 
 	// set position
@@ -78,7 +78,7 @@ UFlowGraphNode* FFlowGraphSchemaAction_NewNode::CreateNode(UEdGraph* ParentGraph
 
 	// call notifies
 	NewGraphNode->PostPlacedNewNode();
-	ParentGraph->NotifyGraphChanged();
+	ParentGraph->NotifyNodeChanged(NewGraphNode);
 
 	FlowAsset->PostEditChange();
 

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -17,8 +17,8 @@
 #include "BlueprintNodeHelpers.h"
 #include "Developer/ToolMenus/Public/ToolMenus.h"
 #include "DiffResults.h"
-#include "EdGraphSchema_K2.h"
 #include "Editor.h"
+#include "FlowLogChannels.h"
 #include "Framework/Commands/GenericCommands.h"
 #include "GraphDiffControl.h"
 #include "GraphEditorActions.h"
@@ -28,6 +28,7 @@
 #include "SourceCodeNavigation.h"
 #include "Textures/SlateIcon.h"
 #include "ToolMenuSection.h"
+#include "Editor/Transactor.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(FlowGraphNode)
 
@@ -199,8 +200,8 @@ void UFlowGraphNode::OnExternalChange()
 
 void UFlowGraphNode::OnGraphRefresh()
 {
-	RefreshContextPins(true);
-}
+	ReconstructNode();
+    }
 
 bool UFlowGraphNode::CanCreateUnderSpecifiedSchema(const UEdGraphSchema* Schema) const
 {
@@ -290,7 +291,7 @@ void UFlowGraphNode::ReconstructNode()
 			return;
 		}
 	}
-
+	
 	if (bIsReconstructingNode)
 	{
 		return;
@@ -298,9 +299,44 @@ void UFlowGraphNode::ReconstructNode()
 
 	bIsReconstructingNode = true;
 
+	if (bFirstRun)
+	{
+		for (UEdGraphPin* Pin : Pins)
+		{
+			switch (Pin->Direction)
+			{
+				case EGPD_Input:
+				{
+					InputPins.Add(Pin);
+					break;
+				}
+				case EGPD_Output:
+				{
+					OutputPins.Add(Pin);
+					break;
+				}
+				default:
+				{
+					UE_LOG(LogFlow, Error, TEXT("Encountered Pin with invalid direction!"));
+				}
+			}
+		}
+		
+		bFirstRun = false;
+	}
+	
 	// Store old pins
 	TArray<UEdGraphPin*> OldPins(Pins);
 
+	bool bHavePinsChanged = HavePinsChanged();
+
+	if (!bHavePinsChanged)
+	{
+		bNeedsFullReconstruction = false;
+		bIsReconstructingNode = false;
+		return;
+	}
+	
 	// Reset pin arrays
 	Pins.Reset();
 	InputPins.Reset();
@@ -317,8 +353,8 @@ void UFlowGraphNode::ReconstructNode()
 
 	// Recreate pins
 	constexpr bool bReconstructNode = false;
-	RefreshContextPins(bReconstructNode);
 
+	RefreshContextPins();
 	AllocateDefaultPins();
 	RewireOldPinsToNewPins(OldPins);
 
@@ -329,7 +365,7 @@ void UFlowGraphNode::ReconstructNode()
 		OldPin->BreakAllPinLinks();
 		DestroyPin(OldPin);
 	}
-
+	
 	bNeedsFullReconstruction = false;
 	bIsReconstructingNode = false;
 }
@@ -1000,12 +1036,12 @@ void UFlowGraphNode::RemoveInstancePin(UEdGraphPin* Pin)
 	GetGraph()->NotifyGraphChanged();
 }
 
-void UFlowGraphNode::RefreshContextPins(const bool bReconstructNode)
+bool UFlowGraphNode::RefreshContextPins()
 {
 	UFlowNode* FlowNode = Cast<UFlowNode>(NodeInstance);
 	if (!IsValid(FlowNode))
 	{
-		return;
+		return false;
 	}
 
 	// Update the auto-generated pins before refreshing context pins
@@ -1028,7 +1064,7 @@ void UFlowGraphNode::RefreshContextPins(const bool bReconstructNode)
 
 	if (!bShouldRefreshContextPins)
 	{
-		return;
+		return false;
 	}
 
 	const TArray<FFlowPin> ContextInputs = FlowNode->GetContextInputs();
@@ -1043,10 +1079,11 @@ void UFlowGraphNode::RefreshContextPins(const bool bReconstructNode)
 	if (bMaintainedNoContextPins || !HavePinsChanged())
 	{
 		// We don't have contextual pins to account for; or the contextual pins have not changed. We can skip now. 
-		return;
+		return false;
 	}
 
 	const FScopedTransaction Transaction(LOCTEXT("RefreshContextPins", "Refresh Context Pins"));
+
 	Modify();
 
 	const UFlowNode* NodeDefaults = FlowNode->GetClass()->GetDefaultObject<UFlowNode>();
@@ -1058,12 +1095,8 @@ void UFlowGraphNode::RefreshContextPins(const bool bReconstructNode)
 	// recreate outputs
 	FlowNode->OutputPins = NodeDefaults->OutputPins;
 	FlowNode->AddOutputPins(ContextOutputs);
-
-	if (bReconstructNode)
-	{
-		ReconstructNode();
-		GetGraph()->NotifyGraphChanged();
-	}
+	
+	return true;
 }
 
 void UFlowGraphNode::GetPinHoverText(const UEdGraphPin& Pin, FString& HoverTextOut) const
@@ -1261,6 +1294,15 @@ void UFlowGraphNode::PostEditUndo()
 		RebuildRuntimeAddOnsFromEditorSubNodes();
 	}
 }
+
+enum class EPinResolveType : uint8
+{
+	OwningNode,
+	LinkedTo,
+	SubPins,
+	ParentPin,
+	ReferencePassThroughConnection
+};
 
 UFlowAsset* UFlowGraphNode::GetFlowAsset() const
 {
@@ -1477,8 +1519,10 @@ void UFlowGraphNode::RebuildRuntimeAddOnsFromEditorSubNodes()
 	// Reconstruct the context pins for all flow nodes after their AddOns have been processed
 	if (IsValid(NodeInstance) && NodeInstance->IsA<UFlowNode>())
 	{
-		constexpr bool bReconstructNode = true;
-		RefreshContextPins(bReconstructNode);
+		if (HavePinsChanged())
+		{
+			ReconstructNode();
+		}
 	}
 }
 

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -81,6 +81,8 @@ void UFlowGraphNode::PostLoad()
 		NodeInstance->FixNode(this); // fix already created nodes
 		SubscribeToExternalChanges();
 	}
+
+	RebuildPinArraysOnLoad();
 }
 
 void UFlowGraphNode::PostDuplicate(bool bDuplicateForPIE)
@@ -282,48 +284,15 @@ void UFlowGraphNode::InsertNewNode(UEdGraphPin* FromPin, UEdGraphPin* NewLinkPin
 
 void UFlowGraphNode::ReconstructNode()
 {
-	if (const UFlowGraph* FlowGraph = GetFlowGraph())
-	{
-		// If the graph is locked, we shouldn't reconstruct nodes 
-		// (all nodes will all be reconstructed when the graph is unlocked)
-
-		if (FlowGraph->IsLocked())
-		{
-			return;
-		}
-	}
-	
-	if (bIsReconstructingNode)
+	if (!ShouldReconstructNode())
 	{
 		return;
 	}
-
+	
 	bIsReconstructingNode = true;
-
-	if (bFirstReconstruction)
-	{
-		RebuildPinArraysOnLoad();
-
-		// If this node already has pins, it must have been loaded and this code is running during load.
-		// Otherwise, we should continue on to build the node for the first time.
-		if (Pins.Num() > 0)
-		{
-			bIsReconstructingNode = false;
-			return;
-		}
-	}
 	
-	// Store old pins
 	TArray<UEdGraphPin*> OldPins(Pins);
-
-	bool bHavePinsChanged = HavePinsChanged();
-
-	if (!bHavePinsChanged && !bNeedsFullReconstruction)
-	{
-		bIsReconstructingNode = false;
-		return;
-	}
-
+	
 	// Harvest the auto-generated pins before refreshing context pins
 	if (UFlowNode* FlowNode = Cast<UFlowNode>(NodeInstance))
 	{
@@ -338,7 +307,6 @@ void UFlowGraphNode::ReconstructNode()
 	OutputPins.Reset();
 	
 	RefreshContextPins();
-	
 	AllocateDefaultPins();
 	RewireOldPinsToNewPins(OldPins);
 
@@ -351,7 +319,6 @@ void UFlowGraphNode::ReconstructNode()
 	}
 	
 	bNeedsFullReconstruction = false;
-	
 	bIsReconstructingNode = false;
 
 	(void)OnReconstructNodeCompleted.ExecuteIfBound();
@@ -1319,7 +1286,7 @@ void UFlowGraphNode::LogError(const FString& MessageToLog, const UFlowNodeBase* 
 	}
 }
 
-bool UFlowGraphNode::HavePinsChanged()
+bool UFlowGraphNode::HavePinsChanged() const
 {
 	const UFlowNode* FlowNodeInstance = Cast<UFlowNode>(NodeInstance);
 	if (!IsValid(FlowNodeInstance))
@@ -1805,6 +1772,31 @@ void UFlowGraphNode::ValidateGraphNode(FFlowMessageLog& MessageLog) const
 	}
 }
 
+bool UFlowGraphNode::ShouldReconstructNode() const
+{
+	// If the graph is locked, we shouldn't reconstruct nodes 
+	// (all nodes will all be reconstructed when the graph is unlocked)
+	if (const UFlowGraph* FlowGraph = GetFlowGraph())
+	{
+		if (FlowGraph->IsLocked())
+		{
+			return false;
+		}
+	}
+
+	if (bIsReconstructingNode)
+	{
+		return false;
+	}
+
+	if (!bNeedsFullReconstruction && !HavePinsChanged())
+	{
+		return false;
+	}
+
+	return true;
+}
+
 bool UFlowGraphNode::IsAncestorNode(const UFlowGraphNode& OtherNode) const
 {
 	const UFlowGraphNode* CurParentNode = ParentNode;
@@ -1843,8 +1835,6 @@ void UFlowGraphNode::RebuildPinArraysOnLoad()
 			}
 		}
 	}
-		
-	bFirstReconstruction = false;
 }
 
 bool UFlowGraphNode::CanAcceptSubNodeAsChild(const UFlowGraphNode& SubNodeToConsider, const TSet<const UEdGraphNode*>& AllRootSubNodesToPaste, FString* OutReasonString) const

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -286,6 +286,8 @@ void UFlowGraphNode::ReconstructNode()
 {
 	if (!ShouldReconstructNode())
 	{
+		// This ensures the 'Refresh Graph' button still rebuilds all of the graph widgets even if the FlowGraphNode has nothing to update.
+		(void)OnReconstructNodeCompleted.ExecuteIfBound();
 		return;
 	}
 	
@@ -1773,6 +1775,11 @@ void UFlowGraphNode::ValidateGraphNode(FFlowMessageLog& MessageLog) const
 
 bool UFlowGraphNode::ShouldReconstructNode() const
 {
+	if (GIsTransacting)
+	{
+		return false;
+	}
+	
 	// If the graph is locked, we shouldn't reconstruct nodes 
 	// (all nodes will all be reconstructed when the graph is unlocked)
 	if (const UFlowGraph* FlowGraph = GetFlowGraph())

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -286,7 +286,7 @@ void UFlowGraphNode::ReconstructNode()
 {
 	if (!ShouldReconstructNode())
 	{
-		// This ensures the 'Refresh Graph' button still rebuilds all of the graph widgets even if the FlowGraphNode has nothing to update.
+		// This ensures the graph editor 'Refresh' button still rebuilds all of the graph widgets even if the FlowGraphNode has nothing to update.
 		(void)OnReconstructNodeCompleted.ExecuteIfBound();
 		return;
 	}

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -300,30 +300,17 @@ void UFlowGraphNode::ReconstructNode()
 
 	bIsReconstructingNode = true;
 
-	if (bFirstRun)
+	if (bFirstReconstruction)
 	{
-		for (UEdGraphPin* Pin : Pins)
+		RebuildPinArraysOnLoad();
+
+		// If this node already has pins, it must have been loaded and this code is running during load.
+		// Otherwise, we should continue on to build the node for the first time.
+		if (Pins.Num() > 0)
 		{
-			switch (Pin->Direction)
-			{
-				case EGPD_Input:
-				{
-					InputPins.Add(Pin);
-					break;
-				}
-				case EGPD_Output:
-				{
-					OutputPins.Add(Pin);
-					break;
-				}
-				default:
-				{
-					UE_LOG(LogFlow, Error, TEXT("Encountered Pin with invalid direction!"));
-				}
-			}
+			bIsReconstructingNode = false;
+			return;
 		}
-		
-		bFirstRun = false;
 	}
 	
 	// Store old pins
@@ -331,17 +318,11 @@ void UFlowGraphNode::ReconstructNode()
 
 	bool bHavePinsChanged = HavePinsChanged();
 
-	if (!bHavePinsChanged)
+	if (!bHavePinsChanged && !bNeedsFullReconstruction)
 	{
-		bNeedsFullReconstruction = false;
 		bIsReconstructingNode = false;
 		return;
 	}
-	
-	// Reset pin arrays
-	Pins.Reset();
-	InputPins.Reset();
-	OutputPins.Reset();
 
 	// Harvest the auto-generated pins before refreshing context pins
 	if (UFlowNode* FlowNode = Cast<UFlowNode>(NodeInstance))
@@ -351,11 +332,13 @@ void UFlowGraphNode::ReconstructNode()
 			FlowAsset->TryUpdateManagedFlowPinsForNode(*FlowNode);
 		}
 	}
-
-	// Recreate pins
-	constexpr bool bReconstructNode = false;
-
+	
+	Pins.Reset();
+	InputPins.Reset();
+	OutputPins.Reset();
+	
 	RefreshContextPins();
+	
 	AllocateDefaultPins();
 	RewireOldPinsToNewPins(OldPins);
 
@@ -368,7 +351,10 @@ void UFlowGraphNode::ReconstructNode()
 	}
 	
 	bNeedsFullReconstruction = false;
+	
 	bIsReconstructingNode = false;
+
+	(void)OnReconstructNodeCompleted.ExecuteIfBound();
 }
 
 void UFlowGraphNode::AllocateDefaultPins()
@@ -459,6 +445,20 @@ void UFlowGraphNode::RewireOldPinsToNewPins(TArray<UEdGraphPin*>& InOldPins)
 		if (OrphanedPin->ParentPin == nullptr)
 		{
 			Pins.Add(OrphanedPin);
+
+			switch (OrphanedPin->Direction)
+			{
+				case EGPD_Input:
+				{
+					InputPins.Add(OrphanedPin);
+					break;
+				}
+				case EGPD_Output:
+				{
+					OutputPins.Add(OrphanedPin);
+					break;
+				}
+			}
 		}
 	}
 }
@@ -543,7 +543,7 @@ void UFlowGraphNode::GetNodeContextMenuActions(class UToolMenu* Menu, class UGra
 
 			if (SupportsContextPins())
 			{
-				Section.AddMenuEntry(FlowGraphCommands.RefreshContextPins);
+				Section.AddMenuEntry(FlowGraphCommands.ReconstructNode);
 			}
 
 			if (CanUserAddInput())
@@ -920,7 +920,8 @@ void UFlowGraphNode::RemoveOrphanedPin(UEdGraphPin* Pin)
 	Pins.Remove(Pin);
 
 	ReconstructNode();
-	GetGraph()->NotifyGraphChanged();
+	
+	GetGraph()->NotifyNodeChanged(this);
 }
 
 bool UFlowGraphNode::SupportsContextPins() const
@@ -1037,12 +1038,17 @@ void UFlowGraphNode::RemoveInstancePin(UEdGraphPin* Pin)
 	GetGraph()->NotifyNodeChanged(this);
 }
 
-bool UFlowGraphNode::RefreshContextPins()
+void UFlowGraphNode::RefreshContextPins()
 {
+	if (GIsTransacting)
+	{
+		return;
+	}
+
 	UFlowNode* FlowNode = Cast<UFlowNode>(NodeInstance);
 	if (!IsValid(FlowNode))
 	{
-		return false;
+		return;
 	}
 
 	// Update the auto-generated pins before refreshing context pins
@@ -1065,7 +1071,7 @@ bool UFlowGraphNode::RefreshContextPins()
 
 	if (!bShouldRefreshContextPins)
 	{
-		return false;
+		return;
 	}
 
 	const TArray<FFlowPin> ContextInputs = FlowNode->GetContextInputs();
@@ -1077,10 +1083,10 @@ bool UFlowGraphNode::RefreshContextPins()
 	// Skip the rest if the node went from no ContextPins to no ContextPins
 	const bool bMaintainedNoContextPins = !bPrevHasContextPins && !bHasContextPins;
 
-	if (bMaintainedNoContextPins || !HavePinsChanged())
+	if (bMaintainedNoContextPins)
 	{
 		// We don't have contextual pins to account for; or the contextual pins have not changed. We can skip now. 
-		return false;
+		return;
 	}
 
 	const FScopedTransaction Transaction(LOCTEXT("RefreshContextPins", "Refresh Context Pins"));
@@ -1089,15 +1095,11 @@ bool UFlowGraphNode::RefreshContextPins()
 
 	const UFlowNode* NodeDefaults = FlowNode->GetClass()->GetDefaultObject<UFlowNode>();
 
-	// recreate inputs
 	FlowNode->InputPins = NodeDefaults->InputPins;
 	FlowNode->AddInputPins(ContextInputs);
 
-	// recreate outputs
 	FlowNode->OutputPins = NodeDefaults->OutputPins;
 	FlowNode->AddOutputPins(ContextOutputs);
-	
-	return true;
 }
 
 void UFlowGraphNode::GetPinHoverText(const UEdGraphPin& Pin, FString& HoverTextOut) const
@@ -1296,15 +1298,6 @@ void UFlowGraphNode::PostEditUndo()
 	}
 }
 
-enum class EPinResolveType : uint8
-{
-	OwningNode,
-	LinkedTo,
-	SubPins,
-	ParentPin,
-	ReferencePassThroughConnection
-};
-
 UFlowAsset* UFlowGraphNode::GetFlowAsset() const
 {
 	if (UFlowGraph* FlowGraph = GetFlowGraph())
@@ -1347,14 +1340,30 @@ bool UFlowGraphNode::HavePinsChanged()
 	AllFlowPins.Append(FlowNodeInstance->GetContextInputs());
 	AllFlowPins.Append(FlowNodeInstance->GetContextOutputs());
 
-	if (Pins.Num() != AllFlowPins.Num())
+	// Orphaned pins need to be stripped from the comparison.
+	TArray<UEdGraphPin*> NormalPins;
+	NormalPins.Reserve(Pins.Num());
+
+	for (int i = 0; i < Pins.Num(); ++i)
+	{
+		UEdGraphPin* Pin = Pins[i];
+
+		if (Pin->bOrphanedPin)
+		{
+			continue;
+		}
+
+		NormalPins.Add(Pin);
+	}
+	
+	if (NormalPins.Num() != AllFlowPins.Num())
 	{
 		// There is a different number of EdGraphPins and Flow Node pins; something changed.
 		return true;
 	}
 
 	TArray<FName> PinNames;
-	for (const UEdGraphPin* Pin : Pins)
+	for (const UEdGraphPin* Pin : NormalPins)
 	{
 		PinNames.Add(Pin->PinName);
 	}
@@ -1456,7 +1465,11 @@ void UFlowGraphNode::NodeConnectionListChanged()
 {
 	Super::NodeConnectionListChanged();
 
-	GetFlowGraph()->UpdateAsset();
+	UFlowGraph* Graph = Cast<UFlowGraph>(GetGraph());
+
+	Graph->GetFlowAsset()->HarvestNodeConnections(Cast<UFlowNode>(GetFlowNodeBase()));
+	
+	GetFlowGraph()->NotifyNodeChanged(this);
 }
 
 FString UFlowGraphNode::GetPropertyNameAndValueForDiff(const FProperty* Prop, const uint8* PropertyAddr) const
@@ -1806,6 +1819,32 @@ bool UFlowGraphNode::IsAncestorNode(const UFlowGraphNode& OtherNode) const
 	}
 
 	return false;
+}
+
+void UFlowGraphNode::RebuildPinArraysOnLoad()
+{
+	for (UEdGraphPin* Pin : Pins)
+	{
+		switch (Pin->Direction)
+		{
+			case EGPD_Input:
+			{
+				InputPins.Add(Pin);
+				break;
+			}
+			case EGPD_Output:
+			{
+				OutputPins.Add(Pin);
+				break;
+			}
+			default:
+			{
+				UE_LOG(LogFlow, Error, TEXT("Encountered Pin with invalid direction!"));
+			}
+		}
+	}
+		
+	bFirstReconstruction = false;
 }
 
 bool UFlowGraphNode::CanAcceptSubNodeAsChild(const UFlowGraphNode& SubNodeToConsider, const TSet<const UEdGraphNode*>& AllRootSubNodesToPaste, FString* OutReasonString) const

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -195,13 +195,14 @@ void UFlowGraphNode::OnExternalChange()
 	bNeedsFullReconstruction = true;
 
 	ReconstructNode();
-	GetGraph()->NotifyGraphChanged();
+	
+	GetGraph()->NotifyNodeChanged(this);
 }
 
 void UFlowGraphNode::OnGraphRefresh()
 {
 	ReconstructNode();
-    }
+}
 
 bool UFlowGraphNode::CanCreateUnderSpecifiedSchema(const UEdGraphSchema* Schema) const
 {
@@ -998,7 +999,7 @@ void UFlowGraphNode::AddInstancePin(const EEdGraphPinDirection Direction, const 
 		CreateOutputPin(PinName, FlowNode->InputPins.Num() + NumberedPinsAmount);
 	}
 
-	GetGraph()->NotifyGraphChanged();
+	GetGraph()->NotifyNodeChanged(this);
 }
 
 void UFlowGraphNode::RemoveInstancePin(UEdGraphPin* Pin)
@@ -1033,7 +1034,7 @@ void UFlowGraphNode::RemoveInstancePin(UEdGraphPin* Pin)
 	}
 
 	ReconstructNode();
-	GetGraph()->NotifyGraphChanged();
+	GetGraph()->NotifyNodeChanged(this);
 }
 
 bool UFlowGraphNode::RefreshContextPins()
@@ -1519,10 +1520,7 @@ void UFlowGraphNode::RebuildRuntimeAddOnsFromEditorSubNodes()
 	// Reconstruct the context pins for all flow nodes after their AddOns have been processed
 	if (IsValid(NodeInstance) && NodeInstance->IsA<UFlowNode>())
 	{
-		if (HavePinsChanged())
-		{
-			ReconstructNode();
-		}
+		ReconstructNode();
 	}
 }
 

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -1295,49 +1295,48 @@ bool UFlowGraphNode::HavePinsChanged() const
 		return true;
 	}
 
-	// Get the pins that are part of the node itself. We use the CDO because it inherently knows about the built-in
-	// pins for this node. 
+	// Get all pins of the FlowNode itself. We use the CDO because it inherently knows about the built-in pins for this node. 
 	const UFlowNode* FlowNodeCDO = FlowNodeInstance->GetClass()->GetDefaultObject<UFlowNode>();
 	check(IsValid(FlowNodeCDO));
 
-	TArray<FFlowPin> AllFlowPins = FlowNodeCDO->GetInputPins();
-	AllFlowPins.Append(FlowNodeCDO->GetOutputPins());
+	TArray<FFlowPin> AllFlowNodePins = FlowNodeCDO->GetInputPins();
+	AllFlowNodePins.Append(FlowNodeCDO->GetOutputPins());
 
-	// Get the contextual pins for the underlying flow node instance.  
-	AllFlowPins.Append(FlowNodeInstance->GetContextInputs());
-	AllFlowPins.Append(FlowNodeInstance->GetContextOutputs());
+	AllFlowNodePins.Append(FlowNodeInstance->GetContextInputs());
+	AllFlowNodePins.Append(FlowNodeInstance->GetContextOutputs());
 
-	// Orphaned pins need to be stripped from the comparison.
-	TArray<UEdGraphPin*> NormalPins;
-	NormalPins.Reserve(Pins.Num());
-
-	for (int i = 0; i < Pins.Num(); ++i)
+	// Invalid FlowNode pins need to be stripped from the comparison
+	for (int i = AllFlowNodePins.Num() - 1; i >= 0; --i)
 	{
-		UEdGraphPin* Pin = Pins[i];
-
-		if (Pin->bOrphanedPin)
+		if (!AllFlowNodePins[i].IsValid())
 		{
-			continue;
+			AllFlowNodePins.RemoveAtSwap(i, EAllowShrinking::No);
 		}
-
-		NormalPins.Add(Pin);
 	}
-	
-	if (NormalPins.Num() != AllFlowPins.Num())
+
+	// Get the current FlowGraphNode pins list - orphaned pins need to be stripped from the current pins.
+	TArray<UEdGraphPin*> AllGraphNodePins = Pins;
+	for (int i = AllGraphNodePins.Num() - 1; i >= 0; --i)
 	{
-		// There is a different number of EdGraphPins and Flow Node pins; something changed.
+		if (AllGraphNodePins[i]->bOrphanedPin)
+		{
+			AllGraphNodePins.RemoveAtSwap(i, EAllowShrinking::No);
+		}
+	}
+
+	// Compare valid pin counts
+	if (AllGraphNodePins.Num() != AllFlowNodePins.Num())
+	{
 		return true;
 	}
 
-	TArray<FName> PinNames;
-	for (const UEdGraphPin* Pin : NormalPins)
+	// Compare valid pin names
+	for (const FFlowPin& FlowNodePin : AllFlowNodePins)
 	{
-		PinNames.Add(Pin->PinName);
-	}
-
-	for (const FFlowPin& Pin : AllFlowPins)
-	{
-		if (!PinNames.Contains(Pin.PinName))
+		if (!AllGraphNodePins.ContainsByPredicate([&FlowNodePin](UEdGraphPin* GraphNodePin)
+		{
+			return GraphNodePin->PinName == FlowNodePin.PinName;
+		}))
 		{
 			// Could not match the pin from the flow node with any of the EdPins array.
 			// we have a mismatch between the ed graph pins and the flow node, something changed. 

--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -56,11 +56,18 @@ void SFlowGraphNode::Construct(const FArguments& InArgs, UFlowGraphNode* InNode)
 
 	FlowGraphNode = InNode;
 	FlowGraphNode->OnSignalModeChanged.BindRaw(this, &SFlowGraphNode::UpdateGraphNode);
+	FlowGraphNode->OnReconstructNodeCompleted.BindRaw(this, &SFlowGraphNode::UpdateGraphNode);
 
 	SetCursor(EMouseCursor::CardinalCross);
 	UpdateGraphNode();
 
 	bDragMarkerVisible = false;
+}
+
+SFlowGraphNode::~SFlowGraphNode()
+{
+	FlowGraphNode->OnSignalModeChanged.Unbind();
+	FlowGraphNode->OnReconstructNodeCompleted.Unbind();
 }
 
 void SFlowGraphNode::GetNodeInfoPopups(FNodeInfoContext* Context, TArray<FGraphInformationPopupInfo>& Popups) const

--- a/Source/FlowEditor/Public/FlowEditorCommands.h
+++ b/Source/FlowEditor/Public/FlowEditorCommands.h
@@ -30,7 +30,7 @@ public:
 	FFlowGraphCommands();
 
 	/** Context Pins */
-	TSharedPtr<FUICommandInfo> RefreshContextPins;
+	TSharedPtr<FUICommandInfo> ReconstructNode;
 
 	/** Pins */
 	TSharedPtr<FUICommandInfo> AddInput;

--- a/Source/FlowEditor/Public/Graph/FlowGraphEditor.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphEditor.h
@@ -94,8 +94,8 @@ protected:
 	virtual void OnNodeDoubleClicked(class UEdGraphNode* Node) const;
 	virtual void OnNodeTitleCommitted(const FText& NewText, ETextCommit::Type CommitInfo, UEdGraphNode* NodeBeingChanged);
 
-	virtual void RefreshContextPins() const;
-	virtual bool CanRefreshContextPins() const;
+	virtual void ReconstructNode() const;
+	virtual bool CanReconstructNode() const;
 
 private:
 	void AddInput() const;

--- a/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
@@ -93,6 +93,8 @@ public:
 
 	virtual void GetGraphNodeContextActions(FGraphContextMenuBuilder& ContextMenuBuilder, int32 SubNodeFlags) const;
 
+	virtual bool ShouldAlwaysPurgeOnModification() const override { return false; }
+	
 	static bool IsAddOnAllowedForSelectedObjects(const TArray<UObject*>& SelectedObjects, const UFlowNodeAddOn* AddOnTemplate);
 
 	// --

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -121,6 +121,9 @@ public:
 
 	bool IsAncestorNode(const UFlowGraphNode& OtherNode) const;
 
+protected:
+	void RebuildPinArraysOnLoad();
+
 //////////////////////////////////////////////////////////////////////////
 // Utils
 
@@ -159,6 +162,9 @@ public:
 
 	void ValidateGraphNode(FFlowMessageLog& MessageLog) const;
 
+protected:
+	bool ShouldReconstructNode() const;
+	
 //////////////////////////////////////////////////////////////////////////
 // Pins
 
@@ -191,9 +197,11 @@ public:
 	// Call node and graph updates manually, if using bBatchRemoval
 	void RemoveInstancePin(UEdGraphPin* Pin);
 
+protected:
 	// Create pins from the context asset, i.e. Sequencer events
-	void RefreshContextPins(const bool bReconstructNode);
-
+	void RefreshContextPins();
+	
+public:
 	// UEdGraphNode
 	virtual void GetPinHoverText(const UEdGraphPin& Pin, FString& HoverTextOut) const override;
 	// --
@@ -225,6 +233,7 @@ private:
 
 public:
 	FFlowGraphNodeEvent OnSignalModeChanged;
+	FFlowGraphNodeEvent OnReconstructNodeCompleted;
 	
 	// Pin activation forced by user during PIE
 	virtual void ForcePinActivation(const FEdGraphPinReference PinReference) const;
@@ -302,7 +311,7 @@ protected:
 
 	void LogError(const FString& MessageToLog, const UFlowNodeBase* FlowNodeBase) const;
 
-	bool HavePinsChanged();
+	bool HavePinsChanged() const;
 
 public:
 	

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -268,9 +268,9 @@ public:
 		FDiffResults& Results);
 
 	//~ Begin UObject Interface
-
+#if WITH_EDITOR
 	virtual void PostEditUndo() override;
-
+#endif
 	// End UObject
 
 	// @return the input pin for this state

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -121,6 +121,9 @@ public:
 
 	bool IsAncestorNode(const UFlowGraphNode& OtherNode) const;
 
+protected:
+	void RebuildPinArraysOnLoad();
+
 //////////////////////////////////////////////////////////////////////////
 // Utils
 
@@ -163,7 +166,6 @@ public:
 // Pins
 
 public:
-	bool bFirstRun = true;
 	TArray<UEdGraphPin*> InputPins;
 	TArray<UEdGraphPin*> OutputPins;
 
@@ -194,8 +196,8 @@ public:
 
 protected:
 	// Create pins from the context asset, i.e. Sequencer events
-	bool RefreshContextPins();
-
+	void RefreshContextPins();
+	
 public:
 	// UEdGraphNode
 	virtual void GetPinHoverText(const UEdGraphPin& Pin, FString& HoverTextOut) const override;
@@ -228,6 +230,7 @@ private:
 
 public:
 	FFlowGraphNodeEvent OnSignalModeChanged;
+	FFlowGraphNodeEvent OnReconstructNodeCompleted;
 	
 	// Pin activation forced by user during PIE
 	virtual void ForcePinActivation(const FEdGraphPinReference PinReference) const;
@@ -343,4 +346,6 @@ private:
 	  * UFlowGraph::RecursivelySetParentNodeForAllSubNodes */
 	UPROPERTY(Transient)
 	TObjectPtr<UFlowGraphNode> ParentNode;
+
+	bool bFirstReconstruction = true;
 };

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -163,6 +163,7 @@ public:
 // Pins
 
 public:
+	bool bFirstRun = true;
 	TArray<UEdGraphPin*> InputPins;
 	TArray<UEdGraphPin*> OutputPins;
 
@@ -191,9 +192,11 @@ public:
 	// Call node and graph updates manually, if using bBatchRemoval
 	void RemoveInstancePin(UEdGraphPin* Pin);
 
+protected:
 	// Create pins from the context asset, i.e. Sequencer events
-	void RefreshContextPins(const bool bReconstructNode);
+	bool RefreshContextPins();
 
+public:
 	// UEdGraphNode
 	virtual void GetPinHoverText(const UEdGraphPin& Pin, FString& HoverTextOut) const override;
 	// --
@@ -259,9 +262,9 @@ public:
 		FDiffResults& Results);
 
 	//~ Begin UObject Interface
-#if WITH_EDITOR
+
 	virtual void PostEditUndo() override;
-#endif
+
 	// End UObject
 
 	// @return the input pin for this state

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -162,6 +162,9 @@ public:
 
 	void ValidateGraphNode(FFlowMessageLog& MessageLog) const;
 
+protected:
+	bool ShouldReconstructNode() const;
+	
 //////////////////////////////////////////////////////////////////////////
 // Pins
 
@@ -308,7 +311,7 @@ protected:
 
 	void LogError(const FString& MessageToLog, const UFlowNodeBase* FlowNodeBase) const;
 
-	bool HavePinsChanged();
+	bool HavePinsChanged() const;
 
 public:
 	
@@ -346,6 +349,4 @@ private:
 	  * UFlowGraph::RecursivelySetParentNodeForAllSubNodes */
 	UPROPERTY(Transient)
 	TObjectPtr<UFlowGraphNode> ParentNode;
-
-	bool bFirstReconstruction = true;
 };

--- a/Source/FlowEditor/Public/Graph/Widgets/SFlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Widgets/SFlowGraphNode.h
@@ -26,6 +26,8 @@ public:
 
 	void Construct(const FArguments& InArgs, UFlowGraphNode* InNode);
 
+	~SFlowGraphNode();
+	
 protected:
 	// SNodePanel::SNode
 	virtual void GetNodeInfoPopups(FNodeInfoContext* Context, TArray<FGraphInformationPopupInfo>& Popups) const override;


### PR DESCRIPTION
The goal of this PR is to make the graph editor stop refreshing the entire graph during as many events as possible. It also fixes a few minor bugs related to orphaned pins, running undo/redo commands on edge cases, and unnecessary graph dirtying on edge cases such as when nodes contain orphaned or invalid pins. 

Undo/redo events unfortunately still rebuild the whole graph (Blueprint graphs seem to do this also; I may check later if there is a way to work around this safely or not).

This is a fairly large PR; I have tested this in a small zoo test graph with lots of different pin setups as much as I can, but some additional testing in a "real world" graph would be wise.

**Breaking Changes:**

1. `public void UFlowGraphNode::RefreshContextPins(bool)` changed to `protected void UFlowGraphNode::RefreshContextPins()`
   - The existing system has some logic which could result in attempts to recursively call `ReconstructNode -> RefreshContextPins -> ReconstructNode -> RefreshContextPins`, currently there are bools to guard against this, but both methods are exposed and this felt unclean to me. My suggestion is to protect `RefreshContextPins` and leave `ReconstructNode` for public usage. Both functions have been reworked.

**Other Major Changes:**

2. `UFlowGraphNode::PostLoad` - now rebuilds the unserialized `InputPins` and `OutputPins` arrays using the serialized `Pins` array.
3. `UFlowAsset::HarvestNodeConnections` - Made this function able to harvest a single node, or harvest the whole graph (pass in nullptr to harvest the whole graph, or pass in a single node to harvest just that node). I then use `UFlowGraphNode::NodeConnectionListChanged` to update node connections for only a single node when its connections are changed.
4. Changed the right-click context menu command, "Refresh Context Pins", to "Reconstruct Node".
5. Modified the following functions to only refresh individual nodes instead of the whole graph by changing `NotifyGraphChanged()` calls to `NotifyNodeChanged(Node)`:
   - `FFlowGraphSchemaAction_NewNode::CreateNode`
   - `UFlowGraphSchema::TryCreateConnection`
   - `UFlowGraphSchema::BreakNodeLinks`
   - `UFlowGraphNode::RemoveOrphanedPin`
   - `UFlowGraphNode::AddInstancePin`
   - `UFlowGraphNode::RemoveInstancePin`
6. `FFlowGraphSchemaAction_NewNode::CreateNode` - now runs `ReconstructNode()` instead of only spawning default pins.
7. `UFlowGraphNode::OnGraphRefresh` - now runs `ReconstructNode()` instead of `RefreshContextPins()`, on all nodes.
8. `UFlowGraphNode::RefreshContextPins` - no longer runs at all if an editor transaction is in progress (running undo/redo).
9. `UFlowGraphNode::HavePinsChanged` - now disregards any orphaned pin connections.
10. Added a new delegate `UFlowGraphNode::OnReconstructNodeCompleted` to trigger rebuild of `SFlowGraphNode` widgets whenever ReconstructNode is called.
11. `SFlowGraphNode` - added destructor to unbind from UFlowGraphNode delegates.
12. `UFlowGraphSchema` - added `virtual bool ShouldAlwaysPurgeOnModification() const override { return false; }` to reduce unnecessary graph refreshes.
13. `UFlowNodeAddOn` - GetContextInput/OutputPins functions changed to ignore invalid pins and write a log warning for invalid pins.