### PR TITLE
UFlowGraphNode::ReconstructNode and associated functions rewrite to clean up graph behavior

### DIFF
--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -316,7 +316,11 @@ void UFlowAsset::RegisterNode(const FGuid& NewGuid, UFlowNode* NewNode)
 	Nodes.Emplace(NewGuid, NewNode);
 
 	HarvestNodeConnections();
-	(void)TryUpdateManagedFlowPinsForNode(*NewNode);
+
+	if (TryUpdateManagedFlowPinsForNode(*NewNode))
+	{
+		(void) NewNode->OnReconstructionRequested.ExecuteIfBound();
+	}
 }
 
 void UFlowAsset::UnregisterNode(const FGuid& NodeGuid)
@@ -491,11 +495,6 @@ bool UFlowAsset::TryUpdateManagedFlowPinsForNode(UFlowNode& FlowNode)
 			if (bAutoOutputDataPinsChanged)
 			{
 				FlowNode.SetAutoOutputDataPins(WorkingData.AutoOutputDataPinsNext);
-			}
-
-			if (FlowNode.GraphNode)
-			{
-				FlowNode.OnReconstructionRequested.ExecuteIfBound();
 			}
 		}
 

--- a/Source/FlowEditor/Private/Graph/FlowGraph.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraph.cpp
@@ -93,15 +93,8 @@ void UFlowGraph::RefreshGraph()
 			}
 		}
 
+		// This function will (eventually) result in all graph nodes being reconstructed
 		UnlockUpdates();
-	}
-
-	// refresh nodes
-	TArray<UFlowGraphNode*> FlowGraphNodes;
-	GetNodesOfClass<UFlowGraphNode>(FlowGraphNodes);
-	for (UFlowGraphNode* GraphNode : FlowGraphNodes)
-	{
-		GraphNode->OnGraphRefresh();
 	}
 }
 
@@ -222,7 +215,11 @@ void UFlowGraph::OnLoaded()
 
 void UFlowGraph::OnSave()
 {
+	bIsSavingGraph = true;
+	
 	UpdateAsset();
+
+	bIsSavingGraph = false;
 }
 
 void UFlowGraph::Initialize()

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -286,48 +286,53 @@ void UFlowGraphNode::InsertNewNode(UEdGraphPin* FromPin, UEdGraphPin* NewLinkPin
 
 void UFlowGraphNode::ReconstructNode()
 {
-	RefreshContextPins();
-
-	if (!ShouldReconstructNode())
+	if (!CanReconstructNode())
 	{
-		// This ensures the graph editor 'Refresh' button still rebuilds all of the graph widgets even if the FlowGraphNode has nothing to update.
-		(void) OnReconstructNodeCompleted.ExecuteIfBound();
-
 		return;
 	}
 	
 	bIsReconstructingNode = true;
+	FScopedTransaction Transaction(LOCTEXT("ReconstructNode", "Reconstruct Node"));
+
+	bool bNodeDataPinsUpdated = TryUpdateAutoDataPins(); // This must be called first, it updates the underlying data for data pins of the flow node 
+	bool bNodeExecPinsUpdated = TryUpdateNodePins(); // Updates all pins of the flow node (native pins, meta auto pins, and context pins which include data pins for now)
+	bool bAreGraphPinsMismatched = !CheckGraphPinsMatchNodePins(); // This must be called last since it checks the existing graph node against the cleaned up FlowNode instance
 	
-	TArray<UEdGraphPin*> OldPins(Pins);
-	
-	// Harvest the auto-generated pins before refreshing context pins
-	if (UFlowNode* FlowNode = Cast<UFlowNode>(NodeInstance))
+	bool bGraphNodeRequiresReconstruction = bNeedsFullReconstruction || bNodeDataPinsUpdated || bNodeExecPinsUpdated || bAreGraphPinsMismatched;
+
+	if (bGraphNodeRequiresReconstruction)
 	{
-		if (UFlowAsset* FlowAsset = NodeInstance->GetFlowAsset())
+		Modify();
+
+		TArray<UEdGraphPin*> OldPins(Pins);
+		
+		Pins.Reset();
+		InputPins.Reset();
+		OutputPins.Reset();
+
+		AllocateDefaultPins();
+		RewireOldPinsToNewPins(OldPins);
+
+		// Destroy old pins
+		for (UEdGraphPin* OldPin : OldPins)
 		{
-			FlowAsset->TryUpdateManagedFlowPinsForNode(*FlowNode);
+			OldPin->Modify();
+			OldPin->BreakAllPinLinks();
+			DestroyPin(OldPin);
 		}
+	
+		bNeedsFullReconstruction = false;
 	}
-	
-	Pins.Reset();
-	InputPins.Reset();
-	OutputPins.Reset();
-	
-	AllocateDefaultPins();
-	RewireOldPinsToNewPins(OldPins);
-
-	// Destroy old pins
-	for (UEdGraphPin* OldPin : OldPins)
+	else
 	{
-		OldPin->Modify();
-		OldPin->BreakAllPinLinks();
-		DestroyPin(OldPin);
+		Transaction.Cancel();
 	}
-	
-	bNeedsFullReconstruction = false;
-	bIsReconstructingNode = false;
 
+	// This ensures the graph editor 'Refresh' button still rebuilds all of the graph widgets even if the FlowGraphNode has nothing to update
+	// Ideally we could get rid of the 'Refresh' button but I think it will keep being useful, esp. for users making rough custom widgets
 	(void) OnReconstructNodeCompleted.ExecuteIfBound();
+
+	bIsReconstructingNode = false;
 }
 
 void UFlowGraphNode::AllocateDefaultPins()
@@ -1018,69 +1023,6 @@ void UFlowGraphNode::RemoveInstancePin(UEdGraphPin* Pin)
 	GetGraph()->NotifyNodeChanged(this);
 }
 
-void UFlowGraphNode::RefreshContextPins()
-{
-	if (GIsTransacting)
-	{
-		return;
-	}
-
-	UFlowNode* FlowNode = Cast<UFlowNode>(NodeInstance);
-	if (!IsValid(FlowNode))
-	{
-		return;
-	}
-
-	// Update the auto-generated pins before refreshing context pins
-	bool bChangedAutoFlowPins = false;
-	if (UFlowAsset* FlowAsset = NodeInstance->GetFlowAsset())
-	{
-		bChangedAutoFlowPins = FlowAsset->TryUpdateManagedFlowPinsForNode(*FlowNode);
-	}
-
-	bool bIsLoad = false;
-	if (const UFlowGraph* FlowGraph = GetFlowGraph())
-	{
-		bIsLoad = FlowGraph->IsLoadingGraph();
-	}
-
-	// Confirm that we should be refreshing context pins
-	const bool bIsAllowedToRefreshPins = !bIsLoad || NodeInstance->CanRefreshContextPinsOnLoad();
-	const bool bShouldConsiderRefreshingContextPins = bIsAllowedToRefreshPins && (SupportsContextPins() || bHasContextPins);
-	const bool bShouldRefreshContextPins = bShouldConsiderRefreshingContextPins || bChangedAutoFlowPins || bNeedsFullReconstruction;
-
-	if (!bShouldRefreshContextPins)
-	{
-		return;
-	}
-
-	const TArray<FFlowPin> ContextInputs = FlowNode->GetContextInputs();
-	const TArray<FFlowPin> ContextOutputs = FlowNode->GetContextOutputs();
-
-	const bool bPrevHasContextPins = bHasContextPins;
-	bHasContextPins = !ContextInputs.IsEmpty() || !ContextOutputs.IsEmpty();
-
-	// Skip the rest if the node went from no ContextPins to no ContextPins
-	const bool bMaintainedNoContextPins = !bPrevHasContextPins && !bHasContextPins;
-
-	if (bMaintainedNoContextPins)
-	{
-		// We don't have contextual pins to account for; or the contextual pins have not changed. We can skip now. 
-		return;
-	}
-
-	const FScopedTransaction Transaction(LOCTEXT("RefreshContextPins", "Refresh Context Pins"));
-
-	Modify();
-
-	const UFlowNode* NodeDefaults = FlowNode->GetClass()->GetDefaultObject<UFlowNode>();
-
-	FlowNode->InputPins = NodeDefaults->InputPins;
-	FlowNode->AddInputPins(ContextInputs);
-
-	FlowNode->OutputPins = NodeDefaults->OutputPins;
-	FlowNode->AddOutputPins(ContextOutputs);
-}
 
 void UFlowGraphNode::GetPinHoverText(const UEdGraphPin& Pin, FString& HoverTextOut) const
 {
@@ -1297,68 +1239,6 @@ void UFlowGraphNode::LogError(const FString& MessageToLog, const UFlowNodeBase* 
 	{
 		FlowAsset->LogError(MessageToLog, FlowNodeBase);
 	}
-}
-
-bool UFlowGraphNode::HavePinsChanged() const
-{
-	const UFlowNode* FlowNodeInstance = Cast<UFlowNode>(NodeInstance);
-	if (!IsValid(FlowNodeInstance))
-	{
-		// default to having changed because we don't have a way to confirm that the pins have remained intact. 
-		return true;
-	}
-
-	// Get all pins of the FlowNode itself. We use the CDO because it inherently knows about the built-in pins for this node. 
-	const UFlowNode* FlowNodeCDO = FlowNodeInstance->GetClass()->GetDefaultObject<UFlowNode>();
-	check(IsValid(FlowNodeCDO));
-
-	TArray<FFlowPin> AllFlowNodePins = FlowNodeCDO->GetInputPins();
-	AllFlowNodePins.Append(FlowNodeCDO->GetOutputPins());
-
-	AllFlowNodePins.Append(FlowNodeInstance->GetContextInputs());
-	AllFlowNodePins.Append(FlowNodeInstance->GetContextOutputs());
-
-	// Invalid FlowNode pins need to be stripped from the comparison
-	for (int i = AllFlowNodePins.Num() - 1; i >= 0; --i)
-	{
-		if (!AllFlowNodePins[i].IsValid())
-		{
-			AllFlowNodePins.RemoveAtSwap(i, EAllowShrinking::No);
-		}
-	}
-
-	// Get the current FlowGraphNode pins list - orphaned pins need to be stripped from the current pins.
-	TArray<UEdGraphPin*> AllGraphNodePins = Pins;
-	for (int i = AllGraphNodePins.Num() - 1; i >= 0; --i)
-	{
-		if (AllGraphNodePins[i]->bOrphanedPin)
-		{
-			AllGraphNodePins.RemoveAtSwap(i, EAllowShrinking::No);
-		}
-	}
-
-	// Compare valid pin counts
-	if (AllGraphNodePins.Num() != AllFlowNodePins.Num())
-	{
-		return true;
-	}
-
-	// Compare valid pin names
-	for (const FFlowPin& FlowNodePin : AllFlowNodePins)
-	{
-		if (!AllGraphNodePins.ContainsByPredicate([&FlowNodePin](UEdGraphPin* GraphNodePin)
-		{
-			return GraphNodePin->PinName == FlowNodePin.PinName;
-		}))
-		{
-			// Could not match the pin from the flow node with any of the EdPins array.
-			// we have a mismatch between the ed graph pins and the flow node, something changed. 
-			return true;
-		}
-	}
-
-	// Nothing changed
-	return false;
 }
 
 void UFlowGraphNode::ResetNodeOwner()
@@ -1784,34 +1664,211 @@ void UFlowGraphNode::ValidateGraphNode(FFlowMessageLog& MessageLog) const
 	}
 }
 
-bool UFlowGraphNode::ShouldReconstructNode() const
+bool UFlowGraphNode::CanReconstructNode() const
 {
-	if (GIsTransacting)
+	// Global states that should prevent ReconstructNode from running
+	if (GIsTransacting || bIsReconstructingNode)
 	{
 		return false;
 	}
 	
-	// If the graph is locked, we shouldn't reconstruct nodes 
-	// (all nodes will all be reconstructed when the graph is unlocked)
+	// Corrupt? This should never happen
+	if (!IsValid(NodeInstance))
+	{
+		UE_LOG(LogFlow, Error, TEXT("FlowGraphNode has no NodeInstance, graph may be corrupt!"))
+		return false;
+	}
+
+	// Corrupt? This should never happen
+	if (!IsValid(GetGraph()))
+	{
+		UE_LOG(LogFlow, Error, TEXT("FlowGraphNode has no owner graph, graph may be corrupt!"))
+		return false;
+	}
+
+	// Don't do anything if the Flow Graph is preventing it
 	if (const UFlowGraph* FlowGraph = GetFlowGraph())
 	{
+		if (FlowGraph->IsLoadingGraph())
+		{
+			//return false;
+		}
+
 		if (FlowGraph->IsLocked())
 		{
 			return false;
 		}
 	}
 
-	if (bIsReconstructingNode)
+	return true;
+}
+
+void CleanInvalidPins(TArray<FFlowPin>& Array)
+{
+	for (int i = Array.Num() - 1; i >= 0; --i)
+	{
+		if (!Array[i].IsValid())
+		{
+			Array.RemoveAtSwap(i, EAllowShrinking::No);
+		}
+	}
+}
+
+void CleanInvalidPins(TArray<UEdGraphPin*>& Array)
+{
+	for (int i = Array.Num() - 1; i >= 0; --i)
+	{
+		if (Array[i]->bOrphanedPin)
+		{
+			Array.RemoveAtSwap(i, EAllowShrinking::No);
+		}
+	}
+}
+
+bool CheckPinsMatch(const TArray<FFlowPin>& LeftPins, const TArray<FFlowPin>& RightPins)
+{
+	if (LeftPins.Num() != RightPins.Num())
 	{
 		return false;
 	}
-
-	if (!bNeedsFullReconstruction && !HavePinsChanged())
+	
+	for (const FFlowPin& Left : LeftPins)
 	{
-		return false;
+		// For each required pin, make sure the existing pins array contains a pin that matches by name and type 
+		if (!RightPins.ContainsByPredicate( [&Left] (const FFlowPin& Right)
+		{
+			bool bNameMatch = Left.PinName == Right.PinName;
+			bool bTypematch = Left.GetPinType() == Right.GetPinType();
+			return bNameMatch && bTypematch;
+		} ))
+		{
+			// Something didn't match!
+			return false;
+		}
 	}
 
 	return true;
+}
+
+bool CheckPinsMatch(const TArray<UEdGraphPin*>& GraphPins, const TArray<FFlowPin>& NodePins)
+{
+	// Compare valid pin counts
+	if (GraphPins.Num() != NodePins.Num())
+	{
+		return false;
+	}
+
+	// Compare valid pin names
+	for (const FFlowPin& FlowNodePin : NodePins)
+	{
+		if (!GraphPins.ContainsByPredicate([&FlowNodePin](UEdGraphPin* GraphNodePin)
+		{
+			return GraphNodePin->PinName == FlowNodePin.PinName;
+		}))
+		{
+			// Could not match the pin from the flow node with any of the EdPins array.
+			// we have a mismatch between the ed graph pins and the flow node, something changed. 
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool UFlowGraphNode::TryUpdateNodePins() const
+{
+	UFlowNode* FlowNodeInstance = Cast<UFlowNode>(NodeInstance);
+	if (!IsValid(FlowNodeInstance))
+	{
+		// default to having changed because we don't have a way to confirm that the pins have remained intact. 
+		return true;
+	}
+
+	// ------------
+	// Get all pins of the FlowNode itself 
+	const UFlowNode* FlowNodeCDO = FlowNodeInstance->GetClass()->GetDefaultObject<UFlowNode>();
+	check(IsValid(FlowNodeCDO));
+
+	// We grab basic built-in input/output pins from the CDO
+	// We grab extra required pins from the actual node as generated context pins (this includes both data pins and other context exec pins) 
+	TArray<FFlowPin> RequiredNodeInputPins = FlowNodeCDO->GetInputPins();
+	RequiredNodeInputPins.Append(FlowNodeInstance->GetContextInputs());
+	CleanInvalidPins(RequiredNodeInputPins);
+
+	TArray<FFlowPin> RequiredNodeOutputPins = FlowNodeCDO->GetOutputPins();
+	RequiredNodeOutputPins.Append(FlowNodeInstance->GetContextOutputs());
+	CleanInvalidPins(RequiredNodeOutputPins);
+
+	// ------------
+	// Get all existing pins of the flow node instance
+	TArray<FFlowPin> ExistingNodeInputPins = FlowNodeInstance->GetInputPins();
+	CleanInvalidPins(ExistingNodeInputPins);
+
+	TArray<FFlowPin> ExistingNodeOutputPins = FlowNodeInstance->GetOutputPins();
+	CleanInvalidPins(ExistingNodeOutputPins);
+
+	// ------------
+	// If required pins don't match existing pins, brute force replace them
+
+	bool bPinsChanged = false;
+	
+	if (!CheckPinsMatch(RequiredNodeInputPins, ExistingNodeInputPins))
+	{
+		FlowNodeInstance->InputPins.Empty(RequiredNodeInputPins.Num());
+		FlowNodeInstance->AddInputPins(RequiredNodeInputPins); // We could just copy it, but this function could do more things one day
+
+		bPinsChanged = true;
+	}
+
+	if (!CheckPinsMatch(RequiredNodeOutputPins, ExistingNodeOutputPins))
+	{
+		FlowNodeInstance->OutputPins.Empty(RequiredNodeOutputPins.Num());
+		FlowNodeInstance->AddOutputPins(RequiredNodeOutputPins); // We could just copy it, but this function could do more things one day
+
+		bPinsChanged = true;
+	}
+
+	return bPinsChanged;
+}
+
+bool UFlowGraphNode::TryUpdateAutoDataPins() const
+{
+	// Attempt to update the manged / auto-generated pins
+	if (UFlowAsset* FlowAsset = NodeInstance->GetFlowAsset())
+	{
+		if (UFlowNode* FlowNodeInstance = Cast<UFlowNode>(NodeInstance))
+		{
+			bool bUpdatedManagedFlowPins = FlowAsset->TryUpdateManagedFlowPinsForNode(*FlowNodeInstance);
+			
+			if (bUpdatedManagedFlowPins)
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+bool UFlowGraphNode::CheckGraphPinsMatchNodePins()
+{	
+	UFlowNode* FlowNodeInstance = Cast<UFlowNode>(NodeInstance);
+
+	if (!IsValid(FlowNodeInstance))
+	{
+		return false;
+	}
+
+	// Get the existing node pins - invalid pins need to be stripped from the check
+	TArray<FFlowPin> ExistingNodePins = FlowNodeInstance->GetInputPins();
+	ExistingNodePins.Append(FlowNodeInstance->GetOutputPins());
+	CleanInvalidPins(ExistingNodePins);
+	
+	// Get the current FlowGraphNode pins list - orphaned pins need to be stripped from the check
+	TArray<UEdGraphPin*> AllGraphNodePins = Pins;
+	CleanInvalidPins(AllGraphNodePins);
+
+	return CheckPinsMatch(AllGraphNodePins, ExistingNodePins);
 }
 
 bool UFlowGraphNode::IsAncestorNode(const UFlowGraphNode& OtherNode) const

--- a/Source/FlowEditor/Public/Graph/FlowGraph.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraph.h
@@ -38,6 +38,8 @@ protected:
 	// is currently loading the Flow Graph (used to suppress some work during load)
 	uint32 bIsLoadingGraph : 1;
 
+	bool bIsSavingGraph = false;
+	
 public:
 	static void CreateGraph(UFlowAsset* InFlowAsset);
 	static void CreateGraph(UFlowAsset* InFlowAsset, TSubclassOf<UFlowGraphSchema> FlowSchema);
@@ -93,4 +95,6 @@ public:
 	void UnlockUpdates();
 
 	bool IsLoadingGraph() const { return bIsLoadingGraph; }
+
+	bool IsSavingGraph() const { return bIsSavingGraph; }
 };

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -164,7 +164,13 @@ public:
 	void ValidateGraphNode(FFlowMessageLog& MessageLog) const;
 
 protected:
-	bool ShouldReconstructNode() const;
+	bool CanReconstructNode() const;
+	
+	bool TryUpdateNodePins() const;
+	
+	bool TryUpdateAutoDataPins() const;
+
+	bool CheckGraphPinsMatchNodePins();
 	
 //////////////////////////////////////////////////////////////////////////
 // Pins
@@ -198,10 +204,6 @@ public:
 	// Call node and graph updates manually, if using bBatchRemoval
 	void RemoveInstancePin(UEdGraphPin* Pin);
 
-protected:
-	// Create pins from the context asset, i.e. Sequencer events
-	void RefreshContextPins();
-	
 public:
 	// UEdGraphNode
 	virtual void GetPinHoverText(const UEdGraphPin& Pin, FString& HoverTextOut) const override;
@@ -311,8 +313,6 @@ protected:
 	virtual void ResetNodeOwner();
 
 	void LogError(const FString& MessageToLog, const UFlowNodeBase* FlowNodeBase) const;
-
-	bool HavePinsChanged() const;
 
 public:
 	

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -38,6 +38,7 @@ private:
 
 	bool bBlueprintCompilationPending;
 	bool bIsReconstructingNode;
+	bool bIsDestroyingNode;
 	bool bNeedsFullReconstruction;
 	static bool bFlowAssetsLoaded;
 


### PR DESCRIPTION
- Removed some duplicate calls to reconstruct nodes; `ReconstructNode()` would frequently run 2 or 3 times before, usually only runs once now
- Added additional flags to skip `ReconstructNode()`: no longer reconstructs before saving the graph, no longer reconstructs a node before deleting the node
- `ReconstructNode()` completely rewritten to clean up logic and resolve bugs with 'false' graph asset dirtying or missed pin change updates
- `UFlowGraphNode::RefreshContextPins()` function completely replaced by two new substantial functions: 
  - `TryUpdateAutoDataPins()`
  - `TryUpdateNodePins()`