### PR TITLE
Properly handle disabling of ViewportStatsSubsystem is UFlowNodeBase/…

### DIFF
--- a/Source/Flow/Private/FlowComponent.cpp
+++ b/Source/Flow/Private/FlowComponent.cpp
@@ -100,6 +100,28 @@ void UFlowComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 	Super::EndPlay(EndPlayReason);
 }
 
+void UFlowComponent::BeginDestroy()
+{
+	// Remark: removing them in the reverse order they where added. It is using RemoveAtSwap()
+	// so removing the first one would change the index of the next one. Removing a delegate in the
+	// middle of the array will invalidate the indices above.
+	if (UWorld* World = GetWorld())
+	{
+		for (int32 Index = ErrorDisplayDelegatesIndices.Num() - 1; Index >= 0; --Index)
+		{
+			if (UViewportStatsSubsystem* StatsSubsystem = World->GetSubsystem<UViewportStatsSubsystem>())
+			{
+				StatsSubsystem->RemoveDisplayDelegate(ErrorDisplayDelegatesIndices[Index]);
+			}
+		}
+	}
+
+	ErrorDisplayDelegatesIndices.Reset();
+
+	// Call it at the end, otherwise WorldPrivate is set to nullptr
+	Super::BeginDestroy();
+}
+
 void UFlowComponent::UnregisterWithFlowSubsystem()
 {
 	if (UFlowSubsystem* FlowSubsystem = GetFlowSubsystem())
@@ -269,16 +291,16 @@ void UFlowComponent::LogError(FString Message, const EFlowOnScreenMessageType On
 
 	if (OnScreenMessageType == EFlowOnScreenMessageType::Permanent)
 	{
-		if (GetWorld())
+		if (UWorld* World = GetWorld())
 		{
-			if (UViewportStatsSubsystem* StatsSubsystem = GetWorld()->GetSubsystem<UViewportStatsSubsystem>())
+			if (UViewportStatsSubsystem* StatsSubsystem = World->GetSubsystem<UViewportStatsSubsystem>())
 			{
-				StatsSubsystem->AddDisplayDelegate([this, Message](FText& OutText, FLinearColor& OutColor)
+				ErrorDisplayDelegatesIndices.Add(StatsSubsystem->AddDisplayDelegate([Message](FText& OutText, FLinearColor& OutColor)
 				{
 					OutText = FText::FromString(Message);
 					OutColor = FLinearColor::Red;
-					return IsValid(this);
-				});
+					return true;
+				}));
 			}
 		}
 	}

--- a/Source/Flow/Private/Nodes/FlowNodeBase.cpp
+++ b/Source/Flow/Private/Nodes/FlowNodeBase.cpp
@@ -786,6 +786,29 @@ FString UFlowNodeBase::GetNodeDescription() const
 }
 #endif
 
+#if !UE_BUILD_SHIPPING
+void UFlowNodeBase::BeginDestroy()
+{
+	// Remark: removing them in the reverse order they where added. It is using RemoveAtSwap()
+	// so removing the first one would change the index of the next one. Removing a delegate in the
+	// middle of the array will invalidate the indices above.
+	for (int32 Index = ErrorDisplayDelegatesIndices.Num() - 1; Index >= 0; --Index)
+	{
+		// Since flow nodes can survive world switches and UViewportStatsSubsystem is a world subsystem, don't attempt to remove any indices with a no-longer existing UViewportStatsSubsystem.
+		const auto& [WeakObjectPtr, DelegateIndex] = ErrorDisplayDelegatesIndices[Index];
+		UViewportStatsSubsystem* StatsSubsystem = WeakObjectPtr.Get();
+		if (StatsSubsystem)
+		{
+			StatsSubsystem->RemoveDisplayDelegate(DelegateIndex);
+		}
+	}
+
+	ErrorDisplayDelegatesIndices.Reset();
+
+	Super::BeginDestroy();
+}
+#endif
+
 void UFlowNodeBase::SetNodeConfigText(const FText& NodeConfigText)
 {
 #if WITH_EDITOR
@@ -810,17 +833,17 @@ void UFlowNodeBase::LogError(FString Message, const EFlowOnScreenMessageType OnS
 		// OnScreen Message
 		if (OnScreenMessageType == EFlowOnScreenMessageType::Permanent)
 		{
-			if (GetWorld())
+			if (UWorld* World = GetWorld())
 			{
-				if (UViewportStatsSubsystem* StatsSubsystem = GetWorld()->GetSubsystem<UViewportStatsSubsystem>())
+				if (UViewportStatsSubsystem* StatsSubsystem = World->GetSubsystem<UViewportStatsSubsystem>())
 				{
-					StatsSubsystem->AddDisplayDelegate([this, Message](FText& OutText, FLinearColor& OutColor)
+					ErrorDisplayDelegatesIndices.Add({StatsSubsystem, StatsSubsystem->AddDisplayDelegate([this, Message](FText& OutText, FLinearColor& OutColor)
 					{
 						OutText = FText::FromString(Message);
 						OutColor = FLinearColor::Red;
 
-						return IsValid(this) && GetFlowNodeSelfOrOwner()->GetActivationState() != EFlowNodeState::NeverActivated;
-					});
+						return GetFlowNodeSelfOrOwner()->GetActivationState() != EFlowNodeState::NeverActivated;
+					})});
 				}
 			}
 		}

--- a/Source/Flow/Public/FlowComponent.h
+++ b/Source/Flow/Public/FlowComponent.h
@@ -69,6 +69,8 @@ public:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
+	virtual void BeginDestroy() override;
+
 	UFUNCTION(BlueprintCallable, Category = "Flow")
 	void AddIdentityTag(const FGameplayTag Tag, const EFlowNetMode NetMode = EFlowNetMode::Authority);
 
@@ -130,6 +132,8 @@ public:
 private:
 	UFUNCTION()
 	void OnRep_SentNotifyTags();
+
+	mutable TArray<int32> ErrorDisplayDelegatesIndices;
 
 public:
 	FFlowComponentNotify OnNotifyFromComponent;

--- a/Source/Flow/Public/Nodes/FlowNodeBase.h
+++ b/Source/Flow/Public/Nodes/FlowNodeBase.h
@@ -384,7 +384,10 @@ public:
 	virtual FString GetNodeDescription() const;
 #endif
 
-protected:	
+#if !UE_BUILD_SHIPPING
+	virtual void BeginDestroy() override;
+#endif
+protected:
 	// Short summary of node's content - displayed over node as NodeInfoPopup
 	UFUNCTION(BlueprintImplementableEvent, Category = "FlowNode", meta = (DisplayName = "Get Node Description"))
 	FString K2_GetNodeDescription() const;
@@ -404,5 +407,6 @@ protected:
 #if !UE_BUILD_SHIPPING
 protected:
 	bool BuildMessage(FString& Message) const;
+	mutable TArray<TPair<TWeakObjectPtr<class UViewportStatsSubsystem>, int32>> ErrorDisplayDelegatesIndices;
 #endif
 };


### PR DESCRIPTION
…UFlowComponent is being destroyed.

On our production, some LogError() was called in UFlowNode_Timer where the input 'In' was called more than once, triggering "Timer already active". Later on, as it was completed inside a flow, UFlowNode_Timer gets garbage collected. The delegate in UViewportStatsSubsystem* would still be called regularly, as IsValid(this) would somehow return true - even though that object was deleted completely, going through the UFlowNodeBase destructor.

As flows can survive world changes, the solution is to keep a TWeakObjectPtr<UViewportStatsSubsystem> along with the int32 index returned by the call to UViewportStatsSubsystem::AddDisplayDelegate(). If the UFlowNodeBase is destroyed after a world change, in its BeginDestroy() call, attempt to get the object pointed to TWeakObjectPtr<UViewportStatsSubsystem> - and if it is stale, don't do anything - it got destroyed anyway. Otherwise, remove the display delegate pointed by its index.

The same mechanism is found in UFlowComponent, except that UActorComponent always work in a single world, so no TWeakObjectPtr<> is necessary.