### PR TITLE
Fix copy-paste breaking reroute node directionality

### DIFF
--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -161,6 +161,13 @@ void UFlowGraphNode::PrepareForCopying()
 	}
 }
 
+void UFlowGraphNode::PostPasteNode()
+{
+	Super::PostPasteNode();
+	//prep reconstruct the node, necessary for copy-paste to handle the reconstruct.
+	bNeedsFullReconstruction = true;
+}
+
 void UFlowGraphNode::PostCopyNode()
 {
 	// Make sure this NodeInstance is owned by the FlowAsset it's being pasted into

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -62,6 +62,7 @@ public:
 	// UEdGraphNode
 	virtual void PostPlacedNewNode() override;
 	virtual void PrepareForCopying() override;
+	virtual void PostPasteNode() override;
     // --
 	
 	void PostCopyNode();


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ae498221-cfeb-43d9-a53e-02a40f57d12f)

Because the graph is locked during pasting, the nodes don't reconstruct until the lock finishes, but when the lock does finish the new nodes aren't marked for reconstruction. This fixes the above issue so the pasted nodes look and are properly constructed (with addons too) after pasting.