### PR TITLE
Add menu and toolbar extensibility managers.

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetEditor.cpp
@@ -25,6 +25,7 @@
 #include "Misc/UObjectToken.h"
 #include "Modules/ModuleManager.h"
 #include "PropertyEditorModule.h"
+#include "FlowEditorModule.h"
 #include "ToolMenus.h"
 #include "Widgets/Docking/SDockTab.h"
 
@@ -366,6 +367,8 @@ void FFlowAssetEditor::InitFlowAssetEditor(const EToolkitMode::Type Mode, const 
 	constexpr bool bCreateDefaultToolbar = true;
 	InitAssetEditor(Mode, InitToolkitHost, TEXT("FlowEditorApp"), StandaloneDefaultLayout, bCreateDefaultStandaloneMenu, bCreateDefaultToolbar, ObjectToEdit, false);
 
+	InitalizeExtenders();
+	
 	RegenerateMenusAndToolbars();
 }
 
@@ -418,6 +421,13 @@ void FFlowAssetEditor::BindToolbarCommands()
 								FCanExecuteAction::CreateSP(this, &FFlowAssetEditor::CanGoToParentInstance),
 								FIsActionChecked(),
 								FIsActionButtonVisible::CreateSP(this, &FFlowAssetEditor::CanGoToParentInstance));
+}
+
+void FFlowAssetEditor::InitalizeExtenders()
+{
+	FFlowEditorModule* FlowEditorModule = &FModuleManager::LoadModuleChecked<FFlowEditorModule>("FlowEditor");
+	AddMenuExtender(FlowEditorModule->GetMenuExtensibilityManager()->GetAllExtenders(GetToolkitCommands(), GetEditingObjects()));
+	AddToolbarExtender(FlowEditorModule->GetToolBarExtensibilityManager()->GetAllExtenders(GetToolkitCommands(), GetEditingObjects()));
 }
 
 void FFlowAssetEditor::RefreshAsset()

--- a/Source/FlowEditor/Private/FlowEditorModule.cpp
+++ b/Source/FlowEditor/Private/FlowEditorModule.cpp
@@ -59,6 +59,9 @@ FAssetCategoryPath FFLowAssetCategoryPaths::Flow(LOCTEXT("Flow", "Flow"));
 
 void FFlowEditorModule::StartupModule()
 {
+	MenuExtensibilityManager = MakeShared<FExtensibilityManager>();
+	ToolBarExtensibilityManager = MakeShared<FExtensibilityManager>();
+	
 	FFlowEditorStyle::Initialize();
 
 	TrySetFlowNodeDisplayStyleDefaults();
@@ -101,6 +104,9 @@ void FFlowEditorModule::StartupModule()
 
 void FFlowEditorModule::ShutdownModule()
 {
+	MenuExtensibilityManager.Reset();
+	ToolBarExtensibilityManager.Reset();
+	
 	FFlowEditorStyle::Shutdown();
 
 	UnregisterDetailCustomizations();

--- a/Source/FlowEditor/Public/Asset/FlowAssetEditor.h
+++ b/Source/FlowEditor/Public/Asset/FlowAssetEditor.h
@@ -126,6 +126,7 @@ public:
 protected:
 	virtual void CreateToolbar();
 	virtual void BindToolbarCommands();
+	virtual void InitalizeExtenders();
 	
 	virtual void RefreshAsset();
 	virtual void RefreshDetails();

--- a/Source/FlowEditor/Public/FlowEditorModule.h
+++ b/Source/FlowEditor/Public/FlowEditorModule.h
@@ -20,7 +20,7 @@ struct FLOWEDITOR_API FFLowAssetCategoryPaths : EAssetCategoryPaths
 	static FAssetCategoryPath Flow;
 };
 
-class FLOWEDITOR_API FFlowEditorModule : public IModuleInterface
+class FLOWEDITOR_API FFlowEditorModule : public IModuleInterface, public IHasMenuExtensibility, public IHasToolBarExtensibility
 {
 public:
 	static EAssetTypeCategories::Type FlowAssetCategory;
@@ -30,9 +30,15 @@ private:
 	TSet<FName> CustomClassLayouts;
 	TSet<FName> CustomStructLayouts;
 
+	TSharedPtr<FExtensibilityManager> MenuExtensibilityManager;
+	TSharedPtr<FExtensibilityManager> ToolBarExtensibilityManager;
+
 public:
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
+
+	virtual TSharedPtr<FExtensibilityManager> GetMenuExtensibilityManager() override { return MenuExtensibilityManager; }
+	virtual TSharedPtr<FExtensibilityManager> GetToolBarExtensibilityManager() override { return ToolBarExtensibilityManager; }
 
 private:
 	void TrySetFlowNodeDisplayStyleDefaults() const;


### PR DESCRIPTION
This will allow to add new options to menu and toolbar for custom flow asset types without the need to extend/override FFlowAssetEditor.