### PR TITLE
Flow Breakpoint fixes

### DIFF
--- a/Source/FlowDebugger/Private/Debugger/FlowDebuggerSubsystem.cpp
+++ b/Source/FlowDebugger/Private/Debugger/FlowDebuggerSubsystem.cpp
@@ -248,8 +248,11 @@ void UFlowDebuggerSubsystem::MarkAsHit(const FGuid& NodeGuid)
 {
 	if (FFlowBreakpoint* NodeBreakpoint = FindBreakpoint(NodeGuid))
 	{
-		NodeBreakpoint->MarkAsHit(true);
-		PauseSession();
+		if (NodeBreakpoint->IsEnabled())
+		{
+			NodeBreakpoint->MarkAsHit(true);
+			PauseSession();
+		}
 	}
 }
 
@@ -257,8 +260,11 @@ void UFlowDebuggerSubsystem::MarkAsHit(const FGuid& NodeGuid, const FName& PinNa
 {
 	if (FFlowBreakpoint* PinBreakpoint = FindBreakpoint(NodeGuid, PinName))
 	{
-		PinBreakpoint->MarkAsHit(true);
-		PauseSession();
+		if (PinBreakpoint->IsEnabled())
+		{
+			PinBreakpoint->MarkAsHit(true);
+			PauseSession();
+		}
 	}
 }
 

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
@@ -1113,7 +1113,10 @@ void SFlowGraphEditor::OnAddBreakpoint() const
 	check(DebuggerSubsystem.IsValid());
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		DebuggerSubsystem->AddBreakpoint(SelectedNode->NodeGuid);
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->AddBreakpoint(SelectedNode->NodeGuid);
+		}
 	}
 }
 
@@ -1122,7 +1125,11 @@ void SFlowGraphEditor::OnAddPinBreakpoint()
 	check(DebuggerSubsystem.IsValid());
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		DebuggerSubsystem->AddBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->AddBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
+		}
 	}
 }
 
@@ -1131,7 +1138,13 @@ bool SFlowGraphEditor::CanAddBreakpoint() const
 	check(DebuggerSubsystem.IsValid());
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		return DebuggerSubsystem->FindBreakpoint(SelectedNode->NodeGuid) == nullptr;
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			if (DebuggerSubsystem->FindBreakpoint(SelectedNode->NodeGuid) == nullptr)
+			{
+				return true;
+			}
+		}
 	}
 
 	return false;
@@ -1142,7 +1155,11 @@ bool SFlowGraphEditor::CanAddPinBreakpoint()
 	check(DebuggerSubsystem.IsValid());
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		return DebuggerSubsystem->FindBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName) == nullptr;
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			return DebuggerSubsystem->FindBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName) == nullptr;
+		}
 	}
 
 	return false;
@@ -1153,7 +1170,10 @@ void SFlowGraphEditor::OnRemoveBreakpoint() const
 	check(DebuggerSubsystem.IsValid());
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		DebuggerSubsystem->RemoveNodeBreakpoint(SelectedNode->NodeGuid);
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->RemoveNodeBreakpoint(SelectedNode->NodeGuid);
+		}
 	}
 }
 
@@ -1162,7 +1182,11 @@ void SFlowGraphEditor::OnRemovePinBreakpoint()
 	check(DebuggerSubsystem.IsValid());
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		DebuggerSubsystem->RemovePinBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->RemovePinBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
+		}
 	}
 }
 
@@ -1171,7 +1195,13 @@ bool SFlowGraphEditor::CanRemoveBreakpoint() const
 	check(DebuggerSubsystem.IsValid());
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		return DebuggerSubsystem->FindBreakpoint(SelectedNode->NodeGuid) != nullptr;
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			if (DebuggerSubsystem->FindBreakpoint(SelectedNode->NodeGuid) != nullptr)
+			{
+				return true;
+			}
+		}
 	}
 
 	return false;
@@ -1182,7 +1212,11 @@ bool SFlowGraphEditor::CanRemovePinBreakpoint()
 	check(DebuggerSubsystem.IsValid());
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		return DebuggerSubsystem->FindBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName) != nullptr;
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			return DebuggerSubsystem->FindBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName) != nullptr;
+		}
 	}
 
 	return false;
@@ -1193,7 +1227,10 @@ void SFlowGraphEditor::OnEnableBreakpoint() const
 	check(DebuggerSubsystem.IsValid());
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		DebuggerSubsystem->SetBreakpointEnabled(SelectedNode->NodeGuid, true);
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->SetBreakpointEnabled(SelectedNode->NodeGuid, true);
+		}
 	}
 }
 
@@ -1202,7 +1239,11 @@ void SFlowGraphEditor::OnEnablePinBreakpoint()
 	check(DebuggerSubsystem.IsValid());
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		DebuggerSubsystem->SetBreakpointEnabled(Pin->GetOwningNode()->NodeGuid, Pin->PinName, true);
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->SetBreakpointEnabled(Pin->GetOwningNode()->NodeGuid, Pin->PinName, true);
+		}
 	}
 }
 
@@ -1210,8 +1251,14 @@ bool SFlowGraphEditor::CanEnableBreakpoint() const
 {
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		const FFlowBreakpoint* Breakpoint = DebuggerSubsystem->FindBreakpoint(SelectedNode->NodeGuid);
-		return Breakpoint && !Breakpoint->IsEnabled();
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			const FFlowBreakpoint* Breakpoint = DebuggerSubsystem->FindBreakpoint(SelectedNode->NodeGuid);
+			if (Breakpoint && !Breakpoint->IsEnabled())
+			{
+				return true;
+			}
+		}
 	}
 
 	return false;
@@ -1221,8 +1268,12 @@ bool SFlowGraphEditor::CanEnablePinBreakpoint()
 {
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		const FFlowBreakpoint* Breakpoint = DebuggerSubsystem->FindBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
-		return Breakpoint && !Breakpoint->IsEnabled();
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			const FFlowBreakpoint* Breakpoint = DebuggerSubsystem->FindBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
+			return Breakpoint && !Breakpoint->IsEnabled();
+		}
 	}
 
 	return false;
@@ -1233,7 +1284,10 @@ void SFlowGraphEditor::OnDisableBreakpoint() const
 	check(DebuggerSubsystem.IsValid());
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		DebuggerSubsystem->SetBreakpointEnabled(SelectedNode->NodeGuid, false);
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->SetBreakpointEnabled(SelectedNode->NodeGuid, false);
+		}
 	}
 }
 
@@ -1242,7 +1296,11 @@ void SFlowGraphEditor::OnDisablePinBreakpoint()
 	check(DebuggerSubsystem.IsValid());
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		DebuggerSubsystem->SetBreakpointEnabled(Pin->GetOwningNode()->NodeGuid, Pin->PinName, false);
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->SetBreakpointEnabled(Pin->GetOwningNode()->NodeGuid, Pin->PinName, false);
+		}
 	}
 }
 
@@ -1251,8 +1309,14 @@ bool SFlowGraphEditor::CanDisableBreakpoint() const
 	check(DebuggerSubsystem.IsValid());
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		const FFlowBreakpoint* Breakpoint = DebuggerSubsystem->FindBreakpoint(SelectedNode->NodeGuid);
-		return Breakpoint && Breakpoint->IsEnabled();
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			const FFlowBreakpoint* Breakpoint = DebuggerSubsystem->FindBreakpoint(SelectedNode->NodeGuid);
+			if (Breakpoint && Breakpoint->IsEnabled())
+			{
+				return true;
+			}
+		}
 	}
 
 	return false;
@@ -1263,8 +1327,12 @@ bool SFlowGraphEditor::CanDisablePinBreakpoint()
 	check(DebuggerSubsystem.IsValid());
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		const FFlowBreakpoint* Breakpoint = DebuggerSubsystem->FindBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
-		return Breakpoint && Breakpoint->IsEnabled();
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			const FFlowBreakpoint* Breakpoint = DebuggerSubsystem->FindBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
+			return Breakpoint && Breakpoint->IsEnabled();
+		}
 	}
 
 	return false;
@@ -1275,7 +1343,10 @@ void SFlowGraphEditor::OnToggleBreakpoint() const
 	check(DebuggerSubsystem.IsValid());
 	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		DebuggerSubsystem->ToggleBreakpoint(SelectedNode->NodeGuid);
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->ToggleBreakpoint(SelectedNode->NodeGuid);
+		}
 	}
 }
 
@@ -1284,18 +1355,39 @@ void SFlowGraphEditor::OnTogglePinBreakpoint()
 	check(DebuggerSubsystem.IsValid());
 	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
 	{
-		DebuggerSubsystem->ToggleBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			DebuggerSubsystem->ToggleBreakpoint(Pin->GetOwningNode()->NodeGuid, Pin->PinName);
+		}
 	}
 }
 
 bool SFlowGraphEditor::CanToggleBreakpoint() const
 {
-	return GetSelectedFlowNodes().Num() > 0;
+	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
+	{
+		if (SelectedNode->CanPlaceBreakpoints())
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 bool SFlowGraphEditor::CanTogglePinBreakpoint()
 {
-	return GetGraphPinForMenu() != nullptr;
+	if (const UEdGraphPin* Pin = GetGraphPinForMenu())
+	{
+		const UFlowGraphNode* OwningNode = Cast<const UFlowGraphNode>(Pin->GetOwningNode());
+		if (!OwningNode || OwningNode->CanPlaceBreakpoints())
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 void SFlowGraphEditor::SetSignalMode(const EFlowSignalMode Mode) const

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -217,6 +217,11 @@ void UFlowGraphNode::OnGraphRefresh()
 	ReconstructNode();
 }
 
+bool UFlowGraphNode::CanPlaceBreakpoints() const
+{
+	return true;
+}
+
 bool UFlowGraphNode::CanCreateUnderSpecifiedSchema(const UEdGraphSchema* Schema) const
 {
 	return Schema->IsA(UFlowGraphSchema::StaticClass());

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode_Reroute.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode_Reroute.cpp
@@ -24,3 +24,8 @@ bool UFlowGraphNode_Reroute::ShouldDrawNodeAsControlPointOnly(int32& OutInputPin
 	OutOutputPinIndex = 1;
 	return true;
 }
+
+bool UFlowGraphNode_Reroute::CanPlaceBreakpoints() const
+{
+	return false;
+}

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode.h
@@ -73,6 +73,7 @@ private:
 
 public:
 	virtual void OnGraphRefresh();
+	virtual bool CanPlaceBreakpoints() const;
 
 //////////////////////////////////////////////////////////////////////////
 // Graph node

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode_Reroute.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode_Reroute.h
@@ -14,4 +14,6 @@ class FLOWEDITOR_API UFlowGraphNode_Reroute : public UFlowGraphNode
 	virtual TSharedPtr<SGraphNode> CreateVisualWidget() override;
 	virtual bool ShouldDrawNodeAsControlPointOnly(int32& OutInputPinIndex, int32& OutOutputPinIndex) const override;
 	// --
+
+	virtual bool CanPlaceBreakpoints() const override;
 };


### PR DESCRIPTION
Add CanPlaceBreakpoints() functionality in UFlowGraphNode, return false on UFlowGraphNode_Reroute.

In SFlowGraphEditor, in Breakpoint() functions, add conditions to check if CanPlaceBreakpoint() on the selected node is true. Also, since multiple breakpoints on nodes can be set/unset at the same time, make the checks in these functions too. Since they are in a for loop, don't return immediately at the first element, but check if it makes sense to return true on the first item that returns true.

Fix breakpoints that could erroneously be added on reroute nodes through the context menu, or through F9, while not being visible at all.

In UFlowDebuggerSubsystem::MarkAsHit() functions, check if the NodeBreakpoint is enabled.