### PR TITLE
Prefer AsyncSaveGameToSlot of the synchronous SaveGameToSlot

### DIFF
--- a/Source/Flow/Private/Nodes/Graph/FlowNode_Checkpoint.cpp
+++ b/Source/Flow/Private/Nodes/Graph/FlowNode_Checkpoint.cpp
@@ -22,7 +22,7 @@ void UFlowNode_Checkpoint::ExecuteInput(const FName& PinName)
 		UFlowSaveGame* NewSaveGame = Cast<UFlowSaveGame>(UGameplayStatics::CreateSaveGameObject(UFlowSaveGame::StaticClass()));
 		GetFlowSubsystem()->OnGameSaved(NewSaveGame);
 
-		UGameplayStatics::SaveGameToSlot(NewSaveGame, NewSaveGame->SaveSlotName, 0);
+		UGameplayStatics::AsyncSaveGameToSlot(NewSaveGame, NewSaveGame->SaveSlotName, 0);
 	}
 
 	TriggerFirstOutput(true);

--- a/Source/Flow/Private/Nodes/Graph/FlowNode_Checkpoint.cpp
+++ b/Source/Flow/Private/Nodes/Graph/FlowNode_Checkpoint.cpp
@@ -9,6 +9,7 @@
 
 UFlowNode_Checkpoint::UFlowNode_Checkpoint(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
+	, bUseAsyncSave(false)
 {
 #if WITH_EDITOR
 	Category = TEXT("Graph");
@@ -22,7 +23,14 @@ void UFlowNode_Checkpoint::ExecuteInput(const FName& PinName)
 		UFlowSaveGame* NewSaveGame = Cast<UFlowSaveGame>(UGameplayStatics::CreateSaveGameObject(UFlowSaveGame::StaticClass()));
 		GetFlowSubsystem()->OnGameSaved(NewSaveGame);
 
-		UGameplayStatics::AsyncSaveGameToSlot(NewSaveGame, NewSaveGame->SaveSlotName, 0);
+		if (bUseAsyncSave)
+		{
+			UGameplayStatics::AsyncSaveGameToSlot(NewSaveGame, NewSaveGame->SaveSlotName, 0);
+		}
+		else
+		{
+			UGameplayStatics::SaveGameToSlot(NewSaveGame, NewSaveGame->SaveSlotName, 0);
+		}
 	}
 
 	TriggerFirstOutput(true);

--- a/Source/Flow/Public/Nodes/Graph/FlowNode_Checkpoint.h
+++ b/Source/Flow/Public/Nodes/Graph/FlowNode_Checkpoint.h
@@ -9,12 +9,15 @@
  * Save the state of the game to the save file
  * It's recommended to replace this with game-specific variant and this node to UFlowGraphSettings::HiddenNodes
  */
-UCLASS(NotBlueprintable, meta = (DisplayName = "Checkpoint", Keywords = "autosave, save"))
+UCLASS(NotBlueprintable, Config = Game, defaultconfig, meta = (DisplayName = "Checkpoint", Keywords = "autosave, save"))
 class FLOW_API UFlowNode_Checkpoint final : public UFlowNode
 {
 	GENERATED_UCLASS_BODY()
 
 protected:
+	UPROPERTY(Config)
+	bool bUseAsyncSave;
+
 	virtual void ExecuteInput(const FName& PinName) override;
 	virtual void OnLoad_Implementation() override;
 };

--- a/Source/Flow/Public/Nodes/Graph/FlowNode_Checkpoint.h
+++ b/Source/Flow/Public/Nodes/Graph/FlowNode_Checkpoint.h
@@ -15,7 +15,10 @@ class FLOW_API UFlowNode_Checkpoint final : public UFlowNode
 	GENERATED_UCLASS_BODY()
 
 protected:
-	UPROPERTY(Config)
+	/* Change setting by editing DefaultGame.ini, add section
+	 * [/Script/Flow.FlowNode_Checkpoint]
+	 * bUseAsyncSave=True */
+	UPROPERTY(VisibleAnywhere, Config)
 	bool bUseAsyncSave;
 
 	virtual void ExecuteInput(const FName& PinName) override;


### PR DESCRIPTION
Hello! I'm working on a title where we essentially banned the use of the synchronous SaveGameToSlot method, in favor of AsyncSaveGameToSlot, which brought me to modify this code in our "fork" (we're in p4) and I decided to have my hand at giving it back.

I get that this save file would be so miniscule that the unease of "causing a hitch" should basically be zero, but I figure, if I understand the code correctly, the save object is synchronously written to memory and any node acting on it will be operating off the in-memory version, while the save object on disk can be written asynchronously as a fire and forget. One thing  I'm unsure of is if there's a scenario where a BP author tries to call `UGameplayStatics::LoadGameFromSlot` using the "FlowSave" slot name, independently of FlowGraph, directly after a checkpoint node. 🤔 

Anyway, at least here for the discussion :)