### PR TITLE
Allow multiple instances on loading Root Flow

### DIFF
--- a/Source/Flow/Private/FlowComponent.cpp
+++ b/Source/Flow/Private/FlowComponent.cpp
@@ -543,7 +543,7 @@ void UFlowComponent::LoadRootFlow()
 	{
 		VerifyIdentityTags();
 
-		GetFlowSubsystem()->LoadRootFlow(this, RootFlow, SavedAssetInstanceName);
+		GetFlowSubsystem()->LoadRootFlow(this, RootFlow, SavedAssetInstanceName, bAllowMultipleInstances);
 		SavedAssetInstanceName = FString();
 	}
 }

--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -375,7 +375,7 @@ void UFlowSubsystem::OnGameLoaded(UFlowSaveGame* SaveGame)
 	// it's recommended to do this by overriding method in the subclass
 }
 
-void UFlowSubsystem::LoadRootFlow(UObject* Owner, UFlowAsset* FlowAsset, const FString& SavedAssetInstanceName)
+void UFlowSubsystem::LoadRootFlow(UObject* Owner, UFlowAsset* FlowAsset, const FString& SavedAssetInstanceName, const bool bAllowMultipleInstances)
 {
 	if (FlowAsset == nullptr || SavedAssetInstanceName.IsEmpty())
 	{
@@ -387,7 +387,7 @@ void UFlowSubsystem::LoadRootFlow(UObject* Owner, UFlowAsset* FlowAsset, const F
 		if (AssetRecord.InstanceName == SavedAssetInstanceName
 			&& (FlowAsset->IsBoundToWorld() == false || AssetRecord.WorldName == GetWorld()->GetName()))
 		{
-			UFlowAsset* LoadedInstance = CreateRootFlow(Owner, FlowAsset, false);
+			UFlowAsset* LoadedInstance = CreateRootFlow(Owner, FlowAsset, bAllowMultipleInstances);
 			if (LoadedInstance)
 			{
 				LoadedInstance->LoadInstance(AssetRecord);

--- a/Source/Flow/Public/FlowSubsystem.h
+++ b/Source/Flow/Public/FlowSubsystem.h
@@ -131,7 +131,7 @@ public:
 	virtual void OnGameLoaded(UFlowSaveGame* SaveGame);
 
 	UFUNCTION(BlueprintCallable, Category = "FlowSubsystem")
-	virtual void LoadRootFlow(UObject* Owner, UFlowAsset* FlowAsset, const FString& SavedAssetInstanceName);
+	virtual void LoadRootFlow(UObject* Owner, UFlowAsset* FlowAsset, const FString& SavedAssetInstanceName, const bool bAllowMultipleInstances);
 
 	UFUNCTION(BlueprintCallable, Category = "FlowSubsystem")
 	virtual void LoadSubFlow(UFlowNode_SubGraph* SubGraphNode, const FString& SavedAssetInstanceName);


### PR DESCRIPTION
We are able to start multiple instances of the same flow asset during a session, however it was not possible to load multiple instances of the same root flow.

* FlowSubsystem::LoadRootFlow takes the bAllowMultipleInstances parameter to allow loading multiple instances of a flow, in the same way you can start multiple instances of a root flow
* FlowComponent calls FlowSubsystem::LoadRootFlow with the value of its public parameter bAllowMultipleInstances