### PR TITLE
Fix Linux packaged build by passing by reference

### DIFF
--- a/Source/Flow/Private/FlowAsset.cpp
+++ b/Source/Flow/Private/FlowAsset.cpp
@@ -224,7 +224,7 @@ bool UFlowAsset::CanFlowAssetUseFlowNodeClass(const UClass& FlowNodeClass) const
 
 bool UFlowAsset::IsFlowNodeClassInDeniedClasses(const UClass& FlowNodeClass) const
 {
-	for (const TSubclassOf<UFlowNodeBase> DeniedNodeClass : DeniedNodeClasses)
+	for (const TSubclassOf<UFlowNodeBase>& DeniedNodeClass : DeniedNodeClasses)
 	{
 		if (DeniedNodeClass && FlowNodeClass.IsChildOf(DeniedNodeClass))
 		{
@@ -239,12 +239,13 @@ bool UFlowAsset::IsFlowNodeClassInDeniedClasses(const UClass& FlowNodeClass) con
 	return false;
 }
 
-bool UFlowAsset::IsFlowNodeClassInAllowedClasses(const UClass& FlowNodeClass, const TSubclassOf<UFlowNodeBase> RequiredAncestor) const
+bool UFlowAsset::IsFlowNodeClassInAllowedClasses(const UClass& FlowNodeClass,
+                                                 const TSubclassOf<UFlowNodeBase>& RequiredAncestor) const
 {
 	if (AllowedNodeClasses.Num() > 0)
 	{
 		bool bAllowedInAsset = false;
-		for (const TSubclassOf<UFlowNodeBase> AllowedNodeClass : AllowedNodeClasses)
+		for (const TSubclassOf<UFlowNodeBase>& AllowedNodeClass : AllowedNodeClasses)
 		{
 			// If a RequiredAncestor is provided, the AllowedNodeClass must be a subclass of the RequiredAncestor
 			if (AllowedNodeClass && FlowNodeClass.IsChildOf(AllowedNodeClass) && (!RequiredAncestor || AllowedNodeClass->IsChildOf(RequiredAncestor)))

--- a/Source/Flow/Public/FlowAsset.h
+++ b/Source/Flow/Public/FlowAsset.h
@@ -124,7 +124,7 @@ protected:
 	bool CanFlowAssetUseFlowNodeClass(const UClass& FlowNodeClass) const;
 	bool CanFlowAssetReferenceFlowNode(const UClass& FlowNodeClass, FText* OutOptionalFailureReason = nullptr) const;
 
-	bool IsFlowNodeClassInAllowedClasses(const UClass& FlowNodeClass, const TSubclassOf<UFlowNodeBase> RequiredAncestor = nullptr) const;
+	bool IsFlowNodeClassInAllowedClasses(const UClass& FlowNodeClass, const TSubclassOf<UFlowNodeBase>& RequiredAncestor = nullptr) const;
 	bool IsFlowNodeClassInDeniedClasses(const UClass& FlowNodeClass) const;
 #endif
 


### PR DESCRIPTION
When packaging a project for Linux, I received the following errors

```
FlowAsset.cpp:227:40: error: loop variable 'DeniedNodeClass' creates a copy from type 'const TSubclassOf<UFlowNodeBase>' [-Werror,-Wrange-loop-construct]
  227 |         for (const TSubclassOf<UFlowNodeBase> DeniedNodeClass : DeniedNodeClasses)
      |                                               ^
```

and

```
FlowAsset.cpp:247:41: error: loop variable 'AllowedNodeClass' creates a copy from type 'const TSubclassOf<UFlowNodeBase>' [-Werror,-Wrange-loop-construct]
  247 |                 for (const TSubclassOf<UFlowNodeBase> AllowedNodeClass : AllowedNodeClasses)
      |                                                       ^
```

To solve this, I changed the loop to use a const reference instead of a const copy. As far as I can tell it doesn't change how it functions. I also changed the function signature to take a const reference while I was at it.