### PR TITLE
add the function BreakSinglePinLink

### DIFF
--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -806,6 +806,12 @@ void UFlowGraphSchema::BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNoti
 	}
 }
 
+void UFlowGraphSchema::BreakSinglePinLink(UEdGraphPin* SourcePin, UEdGraphPin* TargetPin) const
+{
+	Super::BreakSinglePinLink(SourcePin, TargetPin);
+	TargetPin->GetOwningNode()->GetGraph()->NotifyGraphChanged();
+}
+
 int32 UFlowGraphSchema::GetNodeSelectionCount(const UEdGraph* Graph) const
 {
 	return FFlowGraphUtils::GetFlowGraphEditor(Graph)->GetNumberOfSelectedNodes();

--- a/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
@@ -51,6 +51,7 @@ public:
 	virtual FText GetPinDisplayName(const UEdGraphPin* Pin) const override;
 	virtual void BreakNodeLinks(UEdGraphNode& TargetNode) const override;
 	virtual void BreakPinLinks(UEdGraphPin& TargetPin, bool bSendsNodeNotification) const override;
+	virtual void BreakSinglePinLink(UEdGraphPin* SourcePin, UEdGraphPin* TargetPin) const override;
 	virtual int32 GetNodeSelectionCount(const UEdGraph* Graph) const override;
 	virtual TSharedPtr<FEdGraphSchemaAction> GetCreateCommentAction() const override;
 


### PR DESCRIPTION
Implemented a method “ BreakSinglePinLink” to support When you press alt and mouse to the pin link, the node can actually disconnect the link.