### PR TITLE
[Flow Graph Editor - SFlowGraphNode]

### DIFF
--- a/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Widgets/SFlowGraphNode.cpp
@@ -124,7 +124,11 @@ const FSlateBrush* SFlowGraphNode::GetShadowBrush(bool bSelected) const
 	return SGraphNode::GetShadowBrush(bSelected);
 }
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6
 void SFlowGraphNode::GetOverlayBrushes(bool bSelected, const FVector2D WidgetSize, TArray<FOverlayBrushInfo>& Brushes) const
+#else
+void SFlowGraphNode::GetOverlayBrushes(bool bSelected, const FVector2f& WidgetSize, TArray<FOverlayBrushInfo>& Brushes) const
+#endif
 {
 	check(DebuggerSubsystem.IsValid());
 	

--- a/Source/FlowEditor/Public/Graph/Widgets/SFlowGraphNode.h
+++ b/Source/FlowEditor/Public/Graph/Widgets/SFlowGraphNode.h
@@ -34,7 +34,12 @@ protected:
 	// SNodePanel::SNode
 	virtual void GetNodeInfoPopups(FNodeInfoContext* Context, TArray<FGraphInformationPopupInfo>& Popups) const override;
 	virtual const FSlateBrush* GetShadowBrush(bool bSelected) const override;
-	virtual void GetOverlayBrushes(bool bSelected, const FVector2D WidgetSize, TArray<FOverlayBrushInfo>& Brushes) const override;
+
+	#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < 6
+virtual void GetOverlayBrushes(bool bSelected, const FVector2D WidgetSize, TArray<FOverlayBrushInfo>& Brushes) const override;
+#else
+virtual void GetOverlayBrushes(bool bSelected, const FVector2f& WidgetSize, TArray<FOverlayBrushInfo>& Brushes) const override;
+#endif
 	// --
 
 	// SGraphNode


### PR DESCRIPTION
Fixed an issue where break point overlay brushes weren't showing properly due to deprecated code in 5.6