### PR TITLE
fix some missing includes

### DIFF
--- a/Source/FlowEditor/Public/Asset/SFlowDiff.h
+++ b/Source/FlowEditor/Public/Asset/SFlowDiff.h
@@ -4,6 +4,7 @@
 
 #include "IDetailsView.h"
 #include "DiffResults.h"
+#include "GraphEditor.h"
 #include "SDetailsDiff.h"
 #include "Textures/SlateIcon.h"
 

--- a/Source/FlowEditor/Public/FlowEditorModule.h
+++ b/Source/FlowEditor/Public/FlowEditorModule.h
@@ -6,6 +6,7 @@
 #include "IAssetTypeActions.h"
 #include "Modules/ModuleInterface.h"
 #include "PropertyEditorDelegates.h"
+#include "Toolkits/AssetEditorToolkit.h"
 #include "Toolkits/IToolkit.h"
 
 class FSlateStyleSet;

--- a/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "EdGraph/EdGraphSchema.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "Templates/SubclassOf.h"
 #include "FlowGraphSchema.generated.h"
 


### PR DESCRIPTION
Hello! I ran into a few compiler errors after adding the plugin (v2.1-5.6 / c4c33f5) to a fresh, stock, 5.6 project. Seems like they are hidden by unity-compilation perhaps?

To test, I added this to all 3 Build.cs files of the plugin to very unity-compilation isn't hiding any others (not part of this PR):
```
bUseUnity = false;
PCHUsage = PCHUsageMode.NoPCHs;
```

The `FlowGraphSchema.h` one is tricky, without that include the `ENGINE_MAJOR_VERSION`/`ENGINE_MINOR_VERSION` aren't defined so we get the definition of a function in the .cpp without the declaration in this .h