### PR TITLE
Enhance validation in `FlowGraphNode` by adding null checks

### DIFF
--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -65,9 +65,12 @@ UFlowNodeBase* UFlowGraphNode::GetFlowNodeBase() const
 	{
 		if (const UFlowNode* FlowNode = Cast<UFlowNode>(NodeInstance))
 		{
-			if (const UFlowAsset* InspectedInstance = FlowNode->GetFlowAsset()->GetInspectedInstance())
+			if (const UFlowAsset* FlowAsset = FlowNode->GetFlowAsset())
 			{
-				return InspectedInstance->GetNode(FlowNode->GetGuid());
+				if (const UFlowAsset* InspectedInstance = FlowAsset->GetInspectedInstance())
+				{
+					return InspectedInstance->GetNode(FlowNode->GetGuid());
+				}
 			}
 		}
 


### PR DESCRIPTION
The initial issue I wanted to fix was the Ctrl + Shift + X shortcut in the BlueprintAssist plugin, which was causing a crash. This shortcut deletes the selected nodes on the graph and rebuilds the execution pin as if they didn't exist.