### PR TITLE
Fix OnComponentNotify node not using identity tag match type

### DIFF
--- a/Source/Flow/Private/Nodes/Actor/FlowNode_OnNotifyFromActor.cpp
+++ b/Source/Flow/Private/Nodes/Actor/FlowNode_OnNotifyFromActor.cpp
@@ -35,7 +35,24 @@ void UFlowNode_OnNotifyFromActor::ForgetActor(TWeakObjectPtr<AActor> Actor, TWea
 
 void UFlowNode_OnNotifyFromActor::OnNotifyFromComponent(UFlowComponent* Component, const FGameplayTag& Tag)
 {
-	if (Component->IdentityTags.HasAnyExact(IdentityTags) && (!NotifyTags.IsValid() || NotifyTags.HasTagExact(Tag)))
+	bool IdentityMatches = false;
+
+	switch (IdentityMatchType) {
+	case EFlowTagContainerMatchType::HasAny:
+		IdentityMatches = Component->IdentityTags.HasAny(IdentityTags);
+		break;
+	case EFlowTagContainerMatchType::HasAnyExact:
+		IdentityMatches = Component->IdentityTags.HasAnyExact(IdentityTags);
+		break;
+	case EFlowTagContainerMatchType::HasAll:
+		IdentityMatches = Component->IdentityTags.HasAll(IdentityTags);
+		break;
+	case EFlowTagContainerMatchType::HasAllExact:
+		IdentityMatches = Component->IdentityTags.HasAllExact(IdentityTags);
+		break;
+	}
+
+	if (IdentityMatches && (!NotifyTags.IsValid() || NotifyTags.HasTagExact(Tag)))
 	{
 		OnEventReceived();
 	}

--- a/Source/Flow/Private/Nodes/Actor/FlowNode_OnNotifyFromActor.cpp
+++ b/Source/Flow/Private/Nodes/Actor/FlowNode_OnNotifyFromActor.cpp
@@ -37,19 +37,20 @@ void UFlowNode_OnNotifyFromActor::OnNotifyFromComponent(UFlowComponent* Componen
 {
 	bool IdentityMatches = false;
 
-	switch (IdentityMatchType) {
-	case EFlowTagContainerMatchType::HasAny:
-		IdentityMatches = Component->IdentityTags.HasAny(IdentityTags);
-		break;
-	case EFlowTagContainerMatchType::HasAnyExact:
-		IdentityMatches = Component->IdentityTags.HasAnyExact(IdentityTags);
-		break;
-	case EFlowTagContainerMatchType::HasAll:
-		IdentityMatches = Component->IdentityTags.HasAll(IdentityTags);
-		break;
-	case EFlowTagContainerMatchType::HasAllExact:
-		IdentityMatches = Component->IdentityTags.HasAllExact(IdentityTags);
-		break;
+	switch (IdentityMatchType)
+	{
+		case EFlowTagContainerMatchType::HasAny:
+			IdentityMatches = Component->IdentityTags.HasAny(IdentityTags);
+			break;
+		case EFlowTagContainerMatchType::HasAnyExact:
+			IdentityMatches = Component->IdentityTags.HasAnyExact(IdentityTags);
+			break;
+		case EFlowTagContainerMatchType::HasAll:
+			IdentityMatches = Component->IdentityTags.HasAll(IdentityTags);
+			break;
+		case EFlowTagContainerMatchType::HasAllExact:
+			IdentityMatches = Component->IdentityTags.HasAllExact(IdentityTags);
+			break;
 	}
 
 	if (IdentityMatches && (!NotifyTags.IsValid() || NotifyTags.HasTagExact(Tag)))


### PR DESCRIPTION
Fix issue https://github.com/MothCocoon/FlowGraph/issues/314#issue-3725743097

The node OnNotifyFromActor inherits the identity tag match type from the ObserveActor node, however in the function OnNotifyFromComponent it strictly calls HasAnyExact on the identity tags and doesn't use the match type. 
This means any child tags will not be matched even if the match type is set to non-exact.