### PR TITLE
Exposed flow subsystem runtime state fields to subclasses

### DIFF
--- a/Source/Flow/Public/FlowSubsystem.h
+++ b/Source/Flow/Public/FlowSubsystem.h
@@ -36,7 +36,7 @@ public:
 	friend class UFlowComponent;
 	friend class UFlowNode_SubGraph;
 
-private:
+protected:
 	/* All asset templates with active instances */
 	UPROPERTY()
 	TArray<TObjectPtr<UFlowAsset>> InstancedTemplates;


### PR DESCRIPTION
For our custom flow subsystem, we needed access to this state; shouldn't have a big impact.