### PR TITLE
Bugfix for AddOns duplicating when a node is Refreshed in Editor

### DIFF
--- a/Source/Flow/Private/AddOns/FlowNodeAddOn.cpp
+++ b/Source/Flow/Private/AddOns/FlowNodeAddOn.cpp
@@ -17,21 +17,6 @@ UFlowNodeAddOn::UFlowNodeAddOn()
 #endif
 }
 
-#if WITH_EDITOR
-UEdGraphNode* UFlowNodeAddOn::GetGraphNode() const
-{
-	// todo: we might want to cache editor-time pointer to owning Flow Node
-	// it may require more work than just caching it, as pointer needs 
-	// to be updated during editor operations
-	if (const UFlowNode* OwningFlowNode = FindOwningFlowNode())
-	{
-		return OwningFlowNode->GetGraphNode();
-	}
-
-	return nullptr;
-}
-#endif
-
 void UFlowNodeAddOn::InitializeInstance()
 {
 	CacheFlowNode();

--- a/Source/Flow/Public/AddOns/FlowNodeAddOn.h
+++ b/Source/Flow/Public/AddOns/FlowNodeAddOn.h
@@ -40,10 +40,6 @@ protected:
 public:
 	// UFlowNodeBase
 
-#if WITH_EDITOR
-	virtual UEdGraphNode* GetGraphNode() const override;
-#endif
-
 	// AddOns may opt in to be eligible for a given parent
 	// - ParentTemplate - the template of the FlowNode or FlowNodeAddOn that is being considered as a potential parent
 	// - AdditionalAddOnsToAssumeAreChildren - other AddOns to assume that are already child AddOns for the purposes of this test.


### PR DESCRIPTION
AddOns would duplicate in editor when a node was refreshed after integrating from mainline.

AddOns have their own UFlowGraphNode (UEdGraphNode), and shouldn't be returning their UFlowNode's GraphNode.  This is likely what was confusing the editor code and causing a duplication of the addons.

This PR removes the override to GetGraphNode().

There may be other ramifications in the debugger upgrade code where this override was introduced, if it relies on this version's behavior.