### PR TITLE
Made NotifyFromGraph BlueprintCallable

### DIFF
--- a/Source/Flow/Public/FlowComponent.h
+++ b/Source/Flow/Public/FlowComponent.h
@@ -132,6 +132,7 @@ private:
 	FGameplayTagContainer NotifyTagsFromGraph;
 
 public:
+	UFUNCTION(BlueprintCallable, Category = "Flow")
 	virtual void NotifyFromGraph(const FGameplayTagContainer& NotifyTags, const EFlowNetMode NetMode = EFlowNetMode::Authority);
 
 private:


### PR DESCRIPTION
I have a blueprint node and want to notify my parent directly from it. It's possible in C++ so seems reasonable to make it possible in BP too.