### PR TITLE
Data pin retyping

### DIFF
--- a/Source/FlowEditor/Private/Graph/FlowGraph.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraph.cpp
@@ -4,6 +4,7 @@
 #include "Graph/FlowGraphSchema.h"
 #include "Graph/FlowGraphSchema_Actions.h"
 #include "Graph/Nodes/FlowGraphNode.h"
+#include "Graph/Nodes/FlowGraphNode_Reroute.h"
 #include "AddOns/FlowNodeAddOn.h"
 #include "Nodes/FlowNode.h"
 #include "FlowEditorLogChannels.h"
@@ -472,7 +473,50 @@ void UFlowGraph::LockUpdates()
 void UFlowGraph::UnlockUpdates()
 {
 	bLockUpdates = false;
+
+	// Apply any deferred reroute type updates first, while we're in a stable post-paste state.
+	ProcessPendingRerouteTypeFixups();
+
+	// Existing behavior
 	UpdateAsset();
+}
+
+void UFlowGraph::EnqueueRerouteTypeFixup(UFlowGraphNode_Reroute* RerouteNode)
+{
+	if (!IsValid(RerouteNode))
+	{
+		return;
+	}
+
+	// If not locked, run immediately (keeps behavior responsive outside paste/locked updates)
+	if (!IsLocked())
+	{
+		RerouteNode->NodeConnectionListChanged();
+		return;
+	}
+
+	PendingRerouteTypeFixups.Add(RerouteNode);
+}
+
+void UFlowGraph::ProcessPendingRerouteTypeFixups()
+{
+	if (PendingRerouteTypeFixups.Num() == 0)
+	{
+		return;
+	}
+
+	// Move aside so re-entrancy (or new enqueue) doesn't invalidate iteration
+	TSet<TObjectPtr<UFlowGraphNode_Reroute>> Local = MoveTemp(PendingRerouteTypeFixups);
+	PendingRerouteTypeFixups.Reset();
+
+	for (UFlowGraphNode_Reroute* RerouteNode : Local)
+	{
+		if (IsValid(RerouteNode))
+		{
+			// This will call into reroute's centralized retype path via ReconfigureFromConnections()
+			RerouteNode->NodeConnectionListChanged();
+		}
+	}
 }
 
 void UFlowGraph::RecursivelySetupAllFlowGraphNodesForEditing(UFlowGraphNode& FromFlowGraphNode)

--- a/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphSchema.cpp
@@ -293,19 +293,37 @@ UFlowGraphNode* UFlowGraphSchema::CreateDefaultNode(UEdGraph& Graph, const TSubc
 
 bool UFlowGraphSchema::ArePinsCompatible(const UEdGraphPin* PinA, const UEdGraphPin* PinB, const UClass* CallingContext, bool bIgnoreArray) const
 {
-	// Adapted from UEdGraphSchema_K2
-	if ((PinA->Direction == EGPD_Input) && (PinB->Direction == EGPD_Output))
-	{
-		return ArePinTypesCompatible(PinB->PinType, PinA->PinType, CallingContext, bIgnoreArray);
-	}
-	else if ((PinB->Direction == EGPD_Input) && (PinA->Direction == EGPD_Output))
-	{
-		return ArePinTypesCompatible(PinA->PinType, PinB->PinType, CallingContext, bIgnoreArray);
-	}
-	else
+	// First, pins must be direction-compatible (and we need stable Input/Output ordering).
+	const UEdGraphPin* InputPin = nullptr;
+	const UEdGraphPin* OutputPin = nullptr;
+
+	if (!CategorizePinsByDirection(PinA, PinB, /*out*/ InputPin, /*out*/ OutputPin))
 	{
 		return false;
 	}
+
+	check(InputPin);
+	check(OutputPin);
+
+	const bool bInvolvesReroute =
+		(Cast<UFlowGraphNode_Reroute>(PinA->GetOwningNode()) != nullptr) ||
+		(Cast<UFlowGraphNode_Reroute>(PinB->GetOwningNode()) != nullptr);
+
+	if (bInvolvesReroute)
+	{
+		// Exec pins remain strict; defer to canonical exec/type logic.
+		const bool bAnyExec =
+			FFlowPin::IsExecPinCategory(InputPin->PinType.PinCategory) ||
+			FFlowPin::IsExecPinCategory(OutputPin->PinType.PinCategory);
+
+		// Data pins: allow any type when a reroute is involved (reroute will adapt after connection).
+		if (!bAnyExec)
+		{
+			return true;
+		}
+	}
+
+	return ArePinTypesCompatible(OutputPin->PinType, InputPin->PinType, CallingContext, bIgnoreArray);
 }
 
 bool UFlowGraphSchema::ArePinTypesCompatible(
@@ -314,13 +332,11 @@ bool UFlowGraphSchema::ArePinTypesCompatible(
 	const UClass* CallingContext,
 	bool bIgnoreArray) const
 {
-	FPinConnectionResponse ConnectionResponse;
-
 	const bool bIsInputExecPin = FFlowPin::IsExecPinCategory(InputPinType.PinCategory);
 	const bool bIsOutputExecPin = FFlowPin::IsExecPinCategory(OutputPinType.PinCategory);
-
 	if (bIsInputExecPin || bIsOutputExecPin)
 	{
+		// Exec pins must match exactly (exec ↔ exec only).
 		return (bIsInputExecPin && bIsOutputExecPin);
 	}
 
@@ -328,77 +344,39 @@ bool UFlowGraphSchema::ArePinTypesCompatible(
 	MutableThis->EnsurePinTypesInitialized();
 
 	const FFlowPinTypeMatchPolicy* FoundPinTypeMatchPolicy = PinTypeMatchPolicies.Find(InputPinType.PinCategory);
-
-	// PinCategories must match exactly or be in the map of compatible PinCategories for the input pin type
 	if (!FoundPinTypeMatchPolicy)
 	{
-		ConnectionResponse =
-			FPinConnectionResponse(
-				CONNECT_RESPONSE_DISALLOW,
-				FString::Printf(
-					TEXT("Could not find PinTypeMatchPolicy for %s"),
-					*InputPinType.PinCategory.ToString()));
-
+		// Could not find PinTypeMatchPolicy for InputPinType.PinCategory.
 		return false;
 	}
 
 	// PinCategories must match exactly or be in the map of compatible PinCategories for the input pin type
-	const bool bRequirePinCategoryMatch = EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequirePinCategoryMatch);
-	if (bRequirePinCategoryMatch && 
+	const bool bRequirePinCategoryMatch =
+		EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequirePinCategoryMatch);
+
+	if (bRequirePinCategoryMatch &&
 		OutputPinType.PinCategory != InputPinType.PinCategory &&
 		!FoundPinTypeMatchPolicy->PinCategories.Contains(OutputPinType.PinCategory))
 	{
-		ConnectionResponse = 
-			FPinConnectionResponse(
-				CONNECT_RESPONSE_DISALLOW, 
-				FString::Printf(
-					TEXT("Pin type mismatch %s != %s"),
-					*OutputPinType.PinCategory.ToString(),
-					*InputPinType.PinCategory.ToString()));
-
+		// Pin type mismatch OutputPinType.PinCategory != InputPinType.PinCategory (and not in compatible categories list).
 		return false;
 	}
 
 	// RequirePinCategoryMemberReference
-	const bool bRequirePinCategoryMemberReferenceMatch = EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequirePinCategoryMemberReferenceMatch);
-	if (bRequirePinCategoryMemberReferenceMatch && 
+	const bool bRequirePinCategoryMemberReferenceMatch =
+		EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequirePinCategoryMemberReferenceMatch);
+
+	if (bRequirePinCategoryMemberReferenceMatch &&
 		OutputPinType.PinSubCategoryMemberReference != InputPinType.PinSubCategoryMemberReference)
 	{
-		ConnectionResponse =
-			FPinConnectionResponse(
-				CONNECT_RESPONSE_DISALLOW,
-				FString::Printf(
-					TEXT("Pin category member reference mismatch %s != %s"),
-					*OutputPinType.PinSubCategoryMemberReference.MemberName.ToString(),
-					*InputPinType.PinSubCategoryMemberReference.MemberName.ToString()));
-
+		// Pin category member reference mismatch.
 		return false;
 	}
-
-	// TODO (gtaylor) We will want to revisit how we want to use the "PinSubCategory" field of FEdGraphPinType to best effect.
-	// So far, we don't have any use for it in the standard flow types, but if we can dream up a good way to use it 
-	// in supporting other projects, we can add support for it here.
-#if 0 
-	// PinSubCategories must match exactly or be in the map of compatible PinSubCategories for the input pin type
-	const bool bRequirePinSubCategoryMatch = EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequirePinSubCategoryMatch);
-	if (bRequirePinSubCategoryMatch &&
-		OutputPinType.PinSubCategory != InputPinType.PinSubCategory &&
-		!FoundPinTypeMatchPolicy->PinSubCategories.Contains(OutputPinType.PinSubCategory))
-	{
-		ConnectionResponse =
-			FPinConnectionResponse(
-				CONNECT_RESPONSE_DISALLOW,
-				FString::Printf(
-					TEXT("Pin sub-category mismatch %s != %s"),
-					*OutputPinType.PinSubCategory.ToString(),
-					*InputPinType.PinSubCategory.ToString()));
-
-		return false;
-	}
-#endif
 
 	// Container type (Single/Array, etc.)
-	const bool bRequireContainerTypeMatch = EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequireContainerTypeMatch);
+	const bool bRequireContainerTypeMatch =
+		EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequireContainerTypeMatch);
+
 	if (bRequireContainerTypeMatch && OutputPinType.ContainerType != InputPinType.ContainerType)
 	{
 		const bool bIsAnyArray =
@@ -407,26 +385,25 @@ bool UFlowGraphSchema::ArePinTypesCompatible(
 
 		if (!bIgnoreArray || !bIsAnyArray)
 		{
-			ConnectionResponse =
-				FPinConnectionResponse(
-					CONNECT_RESPONSE_DISALLOW,
-					FString::Printf(
-						TEXT("Mismatched container type %s != %s"),
-						*UEnum::GetDisplayValueAsText(OutputPinType.ContainerType).ToString(),
-						*UEnum::GetDisplayValueAsText(InputPinType.ContainerType).ToString()));
-
+			// Mismatched container type (and array mismatch is not being ignored).
 			return false;
 		}
 	}
 
-	const bool bRequirePinSubCategoryObjectMatch = EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequirePinSubCategoryObjectMatch);
+	const bool bRequirePinSubCategoryObjectMatch =
+		EnumHasAnyFlags(FoundPinTypeMatchPolicy->PinTypeMatchRules, EFlowPinTypeMatchRules::RequirePinSubCategoryObjectMatch);
+
 	if (bRequirePinSubCategoryObjectMatch)
 	{
 		const UStruct* OutputStruct = Cast<UStruct>(OutputPinType.PinSubCategoryObject.Get());
 		const UStruct* InputStruct = Cast<UStruct>(InputPinType.PinSubCategoryObject.Get());
 
-		if (!ArePinSubCategoryObjectsCompatible(OutputStruct, InputStruct, *FoundPinTypeMatchPolicy, ConnectionResponse))
+		// ArePinSubCategoryObjectsCompatible() expects to fill an OutConnectionResponse on failure,
+		// but since we only return bool here, we intentionally discard it.
+		FPinConnectionResponse DiscardedResponse;
+		if (!ArePinSubCategoryObjectsCompatible(OutputStruct, InputStruct, *FoundPinTypeMatchPolicy, DiscardedResponse))
 		{
+			// SubCategoryObject types are not compatible per policy.
 			return false;
 		}
 	}
@@ -553,12 +530,12 @@ const FPinConnectionResponse UFlowGraphSchema::CanCreateConnection(const UEdGrap
 
 	FString NodeResponseMessage;
 
-	// node can disallow the connection
-	if (OwningNodeA && OwningNodeA->IsConnectionDisallowed(PinA, PinB, NodeResponseMessage))
+	// Node can disallow the connection
+	if (OwningNodeA->IsConnectionDisallowed(PinA, PinB, NodeResponseMessage))
 	{
 		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, NodeResponseMessage);
 	}
-	if (OwningNodeB && OwningNodeB->IsConnectionDisallowed(PinB, PinA, NodeResponseMessage))
+	if (OwningNodeB->IsConnectionDisallowed(PinB, PinA, NodeResponseMessage))
 	{
 		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, NodeResponseMessage);
 	}
@@ -575,19 +552,16 @@ const FPinConnectionResponse UFlowGraphSchema::CanCreateConnection(const UEdGrap
 	check(InputPin);
 	check(OutputPin);
 
-	// Use the owning flow node's class as the CallingContext
-	constexpr bool bIgnoreArray = false;
-	UClass* CallingContext = nullptr;
-	if (OwningNodeA)
+	// Use the owning flow node's *template* class as the CallingContext.
+	// (Avoid GetFlowNodeBase() here: it may return inspected PIE instances.)
+	const UClass* CallingContext = nullptr;
+	if (const UFlowNodeBase* NodeTemplate = OwningNodeA->GetNodeTemplate())
 	{
-		UFlowNodeBase* FlowNodeBase = OwningNodeA->GetFlowNodeBase();
-		if (FlowNodeBase)
-		{
-			CallingContext = FlowNodeBase->GetClass();
-		}
+		CallingContext = NodeTemplate->GetClass();
 	}
 
 	// Compare the pin types
+	constexpr bool bIgnoreArray = false;
 	const bool bArePinsCompatible = ArePinsCompatible(OutputPin, InputPin, CallingContext, bIgnoreArray);
 	if (!bArePinsCompatible)
 	{
@@ -601,13 +575,20 @@ const FPinConnectionResponse UFlowGraphSchema::CanCreateConnection(const UEdGrap
 	}
 	else if (!NodeResponseMessage.IsEmpty())
 	{
-		ConnectionResponse.Message = FText::Format(LOCTEXT("MultiMsgConnectionResponse", "{0} - {1}"), ConnectionResponse.Message, FText::FromString(NodeResponseMessage));
+		ConnectionResponse.Message = FText::Format(
+			LOCTEXT("MultiMsgConnectionResponse", "{0} - {1}"),
+			ConnectionResponse.Message,
+			FText::FromString(NodeResponseMessage));
 	}
 
 	return ConnectionResponse;
 }
 
-const FPinConnectionResponse UFlowGraphSchema::DetermineConnectionResponseOfCompatibleTypedPins(const UEdGraphPin* PinA, const UEdGraphPin* PinB, const UEdGraphPin* InputPin, const UEdGraphPin* OutputPin) const
+const FPinConnectionResponse UFlowGraphSchema::DetermineConnectionResponseOfCompatibleTypedPins(
+	const UEdGraphPin* PinA,
+	const UEdGraphPin* PinB,
+	const UEdGraphPin* InputPin,
+	const UEdGraphPin* OutputPin) const
 {
 	const bool bIsExistingConnection = PinA->LinkedTo.Contains(PinB);
 	if (bIsExistingConnection)
@@ -618,20 +599,29 @@ const FPinConnectionResponse UFlowGraphSchema::DetermineConnectionResponseOfComp
 
 	checkf(!PinB->LinkedTo.Contains(PinA), TEXT("This should be caught with the bIsExistingConnection test above"));
 
+	const bool bInvolvesReroute =
+		(Cast<UFlowGraphNode_Reroute>(PinA->GetOwningNode()) != nullptr) ||
+		(Cast<UFlowGraphNode_Reroute>(PinB->GetOwningNode()) != nullptr);
+
 	// Break existing connections on outputs for Exec Pins
 	const bool bIsExecPin = FFlowPin::IsExecPinCategory(InputPin->PinType.PinCategory);
 	if (bIsExecPin && OutputPin->LinkedTo.Num() > 0)
 	{
-		const ECanCreateConnectionResponse ReplyBreakInputs = (OutputPin == PinA ? CONNECT_RESPONSE_BREAK_OTHERS_A : CONNECT_RESPONSE_BREAK_OTHERS_B);
-		return FPinConnectionResponse(ReplyBreakInputs, TEXT("Replace existing exec connection"));
+		const ECanCreateConnectionResponse ReplyBreakOutputs =
+			(OutputPin == PinA ? CONNECT_RESPONSE_BREAK_OTHERS_A : CONNECT_RESPONSE_BREAK_OTHERS_B);
+
+		return FPinConnectionResponse(ReplyBreakOutputs, TEXT("Replace existing exec connection"));
 	}
 
 	// Break existing connections on inputs for Data Pins
-	const bool bIsDataPin = !bIsExecPin;
-	if (bIsDataPin && InputPin->LinkedTo.Num() > 0)
+	if (!bIsExecPin && InputPin->LinkedTo.Num() > 0)
 	{
-		const ECanCreateConnectionResponse ReplyBreakInputs = (InputPin == PinA ? CONNECT_RESPONSE_BREAK_OTHERS_A : CONNECT_RESPONSE_BREAK_OTHERS_B);
-		return FPinConnectionResponse(ReplyBreakInputs, TEXT("Replace existing data connection"));
+		const ECanCreateConnectionResponse ReplyBreakInputs =
+			(InputPin == PinA ? CONNECT_RESPONSE_BREAK_OTHERS_A : CONNECT_RESPONSE_BREAK_OTHERS_B);
+
+		return FPinConnectionResponse(
+			ReplyBreakInputs,
+			bInvolvesReroute ? TEXT("Replace existing data connection (reroute will adapt)") : TEXT("Replace existing data connection"));
 	}
 
 	return FPinConnectionResponse(CONNECT_RESPONSE_MAKE, TEXT(""));
@@ -661,7 +651,7 @@ const FPinConnectionResponse UFlowGraphSchema::CanMergeNodes(const UEdGraphNode*
 	FString ReasonString;
 	if (FlowGraphNodeA && FlowGraphNodeB)
 	{
-		TSet<const UEdGraphNode*> OtherGraphNodes; 
+		const TSet<const UEdGraphNode*> OtherGraphNodes;
 		if (!FlowGraphNodeB->CanAcceptSubNodeAsChild(*FlowGraphNodeA, OtherGraphNodes, &ReasonString))
 		{
 			return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, ReasonString);
@@ -679,20 +669,88 @@ const FPinConnectionResponse UFlowGraphSchema::CanMergeNodes(const UEdGraphNode*
 
 bool UFlowGraphSchema::TryCreateConnection(UEdGraphPin* PinA, UEdGraphPin* PinB) const
 {
-	bool bModified = UEdGraphSchema::TryCreateConnection(PinA, PinB);
-	
+	const bool bModified = UEdGraphSchema::TryCreateConnection(PinA, PinB);
+
 	if (bModified)
 	{
 		UFlowGraphNode* FlowGraphNodeA = Cast<UFlowGraphNode>(PinA->GetOwningNode());
 		UFlowGraphNode* FlowGraphNodeB = Cast<UFlowGraphNode>(PinB->GetOwningNode());
 
-		UEdGraph* EdGraph = FlowGraphNodeA->GetGraph();
+		UEdGraph* EdGraph = FlowGraphNodeA ? FlowGraphNodeA->GetGraph() : nullptr;
 
-		EdGraph->NotifyNodeChanged(FlowGraphNodeA);
-		EdGraph->NotifyNodeChanged(FlowGraphNodeB);
+		// If either side is a reroute, re-type it based on the "other" pin and break incompatible links.
+		UFlowGraphNode_Reroute* RerouteNode = Cast<UFlowGraphNode_Reroute>(PinA->GetOwningNode());
+		UEdGraphPin* OtherPin = PinB;
+
+		if (!RerouteNode)
+		{
+			RerouteNode = Cast<UFlowGraphNode_Reroute>(PinB->GetOwningNode());
+			OtherPin = PinA;
+		}
+
+		if (RerouteNode)
+		{
+			check(OtherPin);
+
+			RerouteNode->ApplyTypeFromConnectedPin(*OtherPin);
+
+			const FEdGraphPinType NewType = OtherPin->PinType;
+
+			constexpr bool bForInputPins = true;
+			BreakIncompatibleConnections<bForInputPins>(RerouteNode, RerouteNode->InputPins, NewType);
+
+			constexpr bool bForOutputPins = false;
+			BreakIncompatibleConnections<bForOutputPins>(RerouteNode, RerouteNode->OutputPins, NewType);
+		}
+
+		if (EdGraph)
+		{
+			NotifyNodesChanged(FlowGraphNodeA, FlowGraphNodeB, EdGraph);
+		}
 	}
 
 	return bModified;
+}
+
+template <bool bIsInputPins>
+void UFlowGraphSchema::BreakIncompatibleConnections(UFlowGraphNode_Reroute* RerouteNode, const TArray<UEdGraphPin*>& Pins, FEdGraphPinType NewType) const
+{
+	// Helper function to break incompatible connections on a set of pins
+	for (UEdGraphPin* Pin : Pins)
+	{
+		TArray<UEdGraphPin*> ConnectionsToBreak;
+		for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
+		{
+			bool bIsCompatible;
+
+			if constexpr (bIsInputPins)
+			{
+				// LinkedPin (output) to NewType (input)
+				bIsCompatible = ArePinTypesCompatible(LinkedPin->PinType, NewType, nullptr);
+			}
+			else
+			{
+				// NewType (output) to LinkedPin (input)
+				bIsCompatible = ArePinTypesCompatible(NewType, LinkedPin->PinType, nullptr);
+			}
+
+			if (!bIsCompatible)
+			{
+				ConnectionsToBreak.Add(LinkedPin);
+			}
+		}
+
+		for (UEdGraphPin* PinToBreak : ConnectionsToBreak)
+		{
+			PinToBreak->BreakLinkTo(Pin);
+		}
+	}
+}
+
+void UFlowGraphSchema::NotifyNodesChanged(UFlowGraphNode* NodeA, UFlowGraphNode* NodeB, UEdGraph* Graph) const
+{
+	Graph->NotifyNodeChanged(NodeA);
+	Graph->NotifyNodeChanged(NodeB);
 }
 
 bool UFlowGraphSchema::ShouldHidePinDefaultValue(UEdGraphPin* Pin) const
@@ -935,7 +993,7 @@ void UFlowGraphSchema::UpdateGeneratedDisplayNames()
 		UpdateGeneratedDisplayName(FlowNodeAddOnClass, true);
 	}
 
-	for (TPair<FName, FAssetData>& AssetData : BlueprintFlowNodes)
+	for (const TPair<FName, FAssetData>& AssetData : BlueprintFlowNodes)
 	{
 		if (UBlueprint* Blueprint = Cast<UBlueprint>(AssetData.Value.GetAsset()))
 		{
@@ -944,7 +1002,7 @@ void UFlowGraphSchema::UpdateGeneratedDisplayNames()
 		}
 	}
 
-	for (TPair<FName, FAssetData>& AssetData : BlueprintFlowNodeAddOns)
+	for (const TPair<FName, FAssetData>& AssetData : BlueprintFlowNodeAddOns)
 	{
 		if (UBlueprint* Blueprint = Cast<UBlueprint>(AssetData.Value.GetAsset()))
 		{

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -13,6 +13,7 @@
 #include "Graph/FlowGraphEditorSettings.h"
 #include "Graph/FlowGraphSchema.h"
 #include "Graph/FlowGraphSettings.h"
+#include "Graph/Nodes/FlowGraphNode_Reroute.h"
 #include "Graph/Widgets/SFlowGraphNode.h"
 #include "Graph/Widgets/SGraphEditorActionMenuFlow.h"
 #include "Interfaces/FlowDataPinValueSupplierInterface.h"
@@ -1876,13 +1877,16 @@ bool UFlowGraphNode::TryUpdateNodePins() const
 	UFlowNode* MutableCDO = const_cast<UFlowNode*>(FlowNodeCDO);
 	MutableCDO->FixupDataPinTypes();
 
-	// We grab basic built-in input/output pins from the CDO
-	// We grab extra required pins from the actual node as generated context pins (this includes both data pins and other context exec pins) 
-	TArray<FFlowPin> RequiredNodeInputPins = FlowNodeCDO->GetInputPins();
+	const bool bIsRerouteGraphNode = (Cast<UFlowGraphNode_Reroute>(this) != nullptr);
+
+	// We grab basic built-in input/output pins from:
+	// - CDO for regular nodes
+	// - INSTANCE for reroute nodes (reroute pins are adaptive and may legitimately differ from CDO defaults)
+	TArray<FFlowPin> RequiredNodeInputPins = bIsRerouteGraphNode ? FlowNodeInstance->GetInputPins() : FlowNodeCDO->GetInputPins();
 	RequiredNodeInputPins.Append(FlowNodeInstance->GetContextInputs());
 	CleanInvalidPins(RequiredNodeInputPins);
 
-	TArray<FFlowPin> RequiredNodeOutputPins = FlowNodeCDO->GetOutputPins();
+	TArray<FFlowPin> RequiredNodeOutputPins = bIsRerouteGraphNode ? FlowNodeInstance->GetOutputPins() : FlowNodeCDO->GetOutputPins();
 	RequiredNodeOutputPins.Append(FlowNodeInstance->GetContextOutputs());
 	CleanInvalidPins(RequiredNodeOutputPins);
 

--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode_Reroute.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode_Reroute.cpp
@@ -3,6 +3,9 @@
 #include "Graph/Nodes/FlowGraphNode_Reroute.h"
 #include "SGraphNodeKnot.h"
 
+#include "Graph/FlowGraph.h"
+#include "Graph/Nodes/FlowGraphNode.h"
+#include "Nodes/FlowNode.h"
 #include "Nodes/Route/FlowNode_Reroute.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(FlowGraphNode_Reroute)
@@ -10,7 +13,7 @@
 UFlowGraphNode_Reroute::UFlowGraphNode_Reroute(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 {
-	AssignedNodeClasses = {UFlowNode_Reroute::StaticClass()};
+	AssignedNodeClasses = { UFlowNode_Reroute::StaticClass() };
 }
 
 TSharedPtr<SGraphNode> UFlowGraphNode_Reroute::CreateVisualWidget()
@@ -30,28 +33,165 @@ bool UFlowGraphNode_Reroute::CanPlaceBreakpoints() const
 	return false;
 }
 
-#if WITH_EDITOR
 void UFlowGraphNode_Reroute::ConfigureRerouteNodeFromPinConnections(UEdGraphPin& InPin, UEdGraphPin& OutPin)
 {
-	UFlowNode_Reroute* NewRerouteTemplate = Cast<UFlowNode_Reroute>(NodeInstance);
+	UFlowNode_Reroute* RerouteTemplate = Cast<UFlowNode_Reroute>(NodeInstance);
+	if (!IsValid(RerouteTemplate))
+	{
+		return;
+	}
 
-	UFlowGraphNode* FlowGraphNodeIn = Cast<UFlowGraphNode>(InPin.GetOwningNode());
-	UFlowNode* NodeIn = Cast<UFlowNode>(FlowGraphNodeIn->GetFlowNodeBase());
+	// IMPORTANT:
+	// Use editor templates for "ConnectedNode" context.
+	// GetFlowNodeBase() may return the inspected PIE instance, which we do not want to use for editor graph mutation.
+	const UFlowGraphNode* FlowGraphNodeIn = Cast<UFlowGraphNode>(InPin.GetOwningNode());
+	const UFlowNode* NodeInTemplate = FlowGraphNodeIn ? Cast<UFlowNode>(FlowGraphNodeIn->GetNodeTemplate()) : nullptr;
 
-	UFlowGraphNode* FlowGraphNodeOut = Cast<UFlowGraphNode>(OutPin.GetOwningNode());
-	UFlowNode* NodeOut = Cast<UFlowNode>(FlowGraphNodeOut->GetFlowNodeBase());
+	const UFlowGraphNode* FlowGraphNodeOut = Cast<UFlowGraphNode>(OutPin.GetOwningNode());
+	const UFlowNode* NodeOutTemplate = FlowGraphNodeOut ? Cast<UFlowNode>(FlowGraphNodeOut->GetNodeTemplate()) : nullptr;
 
-	// Update the FlowPin structs on the UFlowNode_Reroute
-	NewRerouteTemplate->ConfigureInputPin(*NodeIn, InPin.PinType);
-	NewRerouteTemplate->ConfigureOutputPin(*NodeOut, OutPin.PinType);
-
+	// Break existing wire first (we're inserting ourselves in between)
 	InPin.BreakLinkTo(&OutPin);
 
-	// Copy the PinType information from the connected pins
- 	InputPins[0]->PinType = InPin.PinType;
- 	OutputPins[0]->PinType = OutPin.PinType;
+	// Canonical reroute type: pick one type for BOTH pins.
+	// Prefer the "source" (OutPin) type since it is the value provider.
+	const FEdGraphPinType CanonicalType = OutPin.PinType;
 
-	InPin.MakeLinkTo(OutputPins[0]);
-	OutPin.MakeLinkTo(InputPins[0]);
+	// Apply to our graph pins (visuals/wire coloring)
+	if (InputPins.Num() > 0 && InputPins[0])
+	{
+		InputPins[0]->PinType = CanonicalType;
+	}
+	if (OutputPins.Num() > 0 && OutputPins[0])
+	{
+		OutputPins[0]->PinType = CanonicalType;
+	}
+
+	// Apply to our template pins (future allocations)
+	{
+		// If possible, configure with context of the connected nodes; otherwise fall back to self.
+		const UFlowNode& InContext = NodeInTemplate ? *NodeInTemplate : *RerouteTemplate;
+		const UFlowNode& OutContext = NodeOutTemplate ? *NodeOutTemplate : *RerouteTemplate;
+
+		RerouteTemplate->ConfigureInputPin(InContext, CanonicalType);
+		RerouteTemplate->ConfigureOutputPin(OutContext, CanonicalType);
+	}
+
+	// Restore reroute wiring
+	if (OutputPins.Num() > 0 && OutputPins[0])
+	{
+		InPin.MakeLinkTo(OutputPins[0]);
+	}
+	if (InputPins.Num() > 0 && InputPins[0])
+	{
+		OutPin.MakeLinkTo(InputPins[0]);
+	}
+
+	// Nudge visuals
+	if (UEdGraph* Graph = GetGraph())
+	{
+		Graph->NotifyNodeChanged(this);
+	}
 }
-#endif
+
+void UFlowGraphNode_Reroute::NodeConnectionListChanged()
+{
+	Super::NodeConnectionListChanged();
+	ReconfigureFromConnections();
+}
+
+void UFlowGraphNode_Reroute::ApplyTypeFromConnectedPin(const UEdGraphPin& OtherPin)
+{
+	if (InputPins.Num() == 0 || OutputPins.Num() == 0)
+	{
+		return;
+	}
+
+	UEdGraphPin* const InputPin = InputPins[0];
+	UEdGraphPin* const OutputPin = OutputPins[0];
+	if (!InputPin || !OutputPin)
+	{
+		return;
+	}
+
+	UFlowNode_Reroute* RerouteTemplate = Cast<UFlowNode_Reroute>(NodeInstance);
+	if (!IsValid(RerouteTemplate))
+	{
+		return;
+	}
+
+	const FEdGraphPinType NewType = OtherPin.PinType;
+
+	// Nothing to do?
+	if (InputPin->PinType == NewType && OutputPin->PinType == NewType)
+	{
+		return;
+	}
+
+	// Apply to graph pins (visual + connection coloring)
+	InputPin->PinType = NewType;
+	OutputPin->PinType = NewType;
+
+	// Update template pins too, so future reconstructions allocate correct pin types.
+	// Pass "connected node" context if possible; fall back to self.
+	const UFlowNode* ConnectedTemplate = nullptr;
+	if (const UFlowGraphNode* OtherGraphNode = Cast<UFlowGraphNode>(OtherPin.GetOwningNode()))
+	{
+		ConnectedTemplate = Cast<UFlowNode>(OtherGraphNode->GetNodeTemplate());
+	}
+	const UFlowNode& ConnectedNodeRef = ConnectedTemplate ? *ConnectedTemplate : *RerouteTemplate;
+
+	RerouteTemplate->ConfigureInputPin(ConnectedNodeRef, NewType);
+	RerouteTemplate->ConfigureOutputPin(ConnectedNodeRef, NewType);
+
+	// Avoid reconstruct storms (esp. during paste). PinType changes are enough for visuals/wire colors.
+	// If the graph is locked, defer the retype pass until UnlockUpdates().
+	if (UFlowGraph* FlowGraph = Cast<UFlowGraph>(GetGraph()))
+	{
+		if (FlowGraph->IsLocked())
+		{
+			FlowGraph->EnqueueRerouteTypeFixup(this);
+			return;
+		}
+	}
+
+	if (UEdGraph* Graph = GetGraph())
+	{
+		Graph->NotifyNodeChanged(this);
+	}
+}
+
+void UFlowGraphNode_Reroute::ReconfigureFromConnections()
+{
+	if (InputPins.Num() == 0 || OutputPins.Num() == 0)
+	{
+		return;
+	}
+
+	UEdGraphPin* const InputPin = InputPins[0];
+	UEdGraphPin* const OutputPin = OutputPins[0];
+	if (!InputPin || !OutputPin)
+	{
+		return;
+	}
+
+	// Determine desired type from whichever side is connected
+	const UEdGraphPin* TypeSourceLinkedPin = nullptr;
+
+	if (InputPin->LinkedTo.Num() > 0 && InputPin->LinkedTo[0])
+	{
+		TypeSourceLinkedPin = InputPin->LinkedTo[0];
+	}
+	else if (OutputPin->LinkedTo.Num() > 0 && OutputPin->LinkedTo[0])
+	{
+		TypeSourceLinkedPin = OutputPin->LinkedTo[0];
+	}
+
+	if (!TypeSourceLinkedPin)
+	{
+		// No connections => don't reset type here. Keep last known type.
+		return;
+	}
+
+	ApplyTypeFromConnectedPin(*TypeSourceLinkedPin);
+}

--- a/Source/FlowEditor/Public/Graph/FlowGraph.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraph.h
@@ -1,3 +1,4 @@
+// FlowGraph.h
 // Copyright https://github.com/MothCocoon/FlowGraph/graphs/contributors
 #pragma once
 
@@ -8,6 +9,7 @@
 
 class SFlowGraphEditor;
 class UFlowGraphNode;
+class UFlowGraphNode_Reroute;
 class UFlowGraphSchema;
 
 /**
@@ -33,7 +35,11 @@ protected:
 	uint32 bIsLoadingGraph : 1;
 
 	bool bIsSavingGraph = false;
-	
+
+	// Reroute nodes that requested a post-unlock type fixup (avoids reconstruct storms on paste)
+	UPROPERTY(Transient)
+	TSet<TObjectPtr<UFlowGraphNode_Reroute>> PendingRerouteTypeFixups;
+
 public:
 	static void CreateGraph(UFlowAsset* InFlowAsset);
 	static void CreateGraph(UFlowAsset* InFlowAsset, TSubclassOf<UFlowGraphSchema> FlowSchema);
@@ -44,6 +50,13 @@ protected:
 
 	void RecursivelyRefreshAddOns(UFlowGraphNode& FromFlowGraphNode);
 	static void RecursivelySetupAllFlowGraphNodesForEditing(UFlowGraphNode& FromFlowGraphNode);
+
+	// Run deferred reroute retyping after unlocking updates
+	void ProcessPendingRerouteTypeFixups();
+
+public:
+	// Called by reroute nodes when graph is locked and type changes should be deferred
+	void EnqueueRerouteTypeFixup(UFlowGraphNode_Reroute* RerouteNode);
 
 public:	
 	// UEdGraph

--- a/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSchema.h
@@ -14,6 +14,7 @@ class UFlowNodeAddOn;
 class UFlowNodeBase;
 class UFlowGraphNode;
 struct FFlowPinType;
+class UFlowGraphNode_Reroute;
 
 DECLARE_MULTICAST_DELEGATE(FFlowGraphSchemaRefresh);
 
@@ -134,6 +135,13 @@ protected:
 	virtual void InitializedPinTypes();
 
 	static UFlowGraphNode* CreateDefaultNode(UEdGraph& Graph, const TSubclassOf<UFlowNode>& NodeClass, const FVector2D& Offset, bool bPlacedAsGhostNode);
+
+	// Helper to break incompatible connections on a set of pins
+	template <bool bIsInputPins>
+	void BreakIncompatibleConnections(UFlowGraphNode_Reroute* RerouteNode, const TArray<UEdGraphPin*>& Pins, FEdGraphPinType NewType) const;
+
+	// Handles post-connection notifications for affected nodes
+	void NotifyNodesChanged(UFlowGraphNode* NodeA, UFlowGraphNode* NodeB, UEdGraph* Graph) const;
 
 private:
 	static void ApplyNodeOrAddOnFilter(const UFlowAsset* AssetClassDefaults, const UClass* FlowNodeClass, TArray<UFlowNodeBase*>& FilteredNodes);

--- a/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode_Reroute.h
+++ b/Source/FlowEditor/Public/Graph/Nodes/FlowGraphNode_Reroute.h
@@ -17,4 +17,18 @@ class FLOWEDITOR_API UFlowGraphNode_Reroute : public UFlowGraphNode
 	virtual bool CanPlaceBreakpoints() const override;
 
 	void ConfigureRerouteNodeFromPinConnections(UEdGraphPin& InPin, UEdGraphPin &OutPin);
+
+	virtual void NodeConnectionListChanged() override;
+
+	/**
+	* Re-type this reroute based on a pin it is connected to (or is being connected to).
+	* This is the single place that should:
+	* - update reroute graph pin types
+	* - update reroute template (UFlowNode_Reroute) pin types
+	* - refresh visuals without forcing a reconstruct storm
+	*/
+	void ApplyTypeFromConnectedPin(const UEdGraphPin& OtherPin);
+
+private:
+	void ReconfigureFromConnections();
 };


### PR DESCRIPTION
for a reroute node, connecting to a new type with a data pin will change its type and break any incompatible connections to the reroute

also fixed copy/paste reroute nodes losing their type

also did some code refactoring to clean up the schema connection checking code a bit.