### PR TITLE
Fix FlowGraphSettings: change TSubclassOf --> TSoftClassPtr

### DIFF
--- a/Source/FlowEditor/Private/Asset/FlowAssetFactory.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetFactory.cpp
@@ -76,10 +76,14 @@ bool UFlowAssetFactory::ConfigureProperties()
 
 bool UFlowAssetFactory::ConfigurePropertiesInternal(const FText& TitleText)
 {
-	AssetClass = GetDefault<UFlowGraphSettings>()->DefaultFlowAssetClass.LoadSynchronous();
-	if (AssetClass) // Class was set in settings
+	const TSoftClassPtr<UFlowAsset> DefaultClass = GetDefault<UFlowGraphSettings>()->DefaultFlowAssetClass; 
+	if (!DefaultClass.IsNull())
 	{
-		return true;
+		AssetClass = DefaultClass.LoadSynchronous();
+		if (AssetClass) // Class was set in settings
+		{
+			return true;
+		}
 	}
 
 	// Load the Class Viewer module to display a class picker

--- a/Source/FlowEditor/Private/Asset/FlowAssetFactory.cpp
+++ b/Source/FlowEditor/Private/Asset/FlowAssetFactory.cpp
@@ -76,7 +76,7 @@ bool UFlowAssetFactory::ConfigureProperties()
 
 bool UFlowAssetFactory::ConfigurePropertiesInternal(const FText& TitleText)
 {
-	AssetClass = GetDefault<UFlowGraphSettings>()->DefaultFlowAssetClass;
+	AssetClass = GetDefault<UFlowGraphSettings>()->DefaultFlowAssetClass.LoadSynchronous();
 	if (AssetClass) // Class was set in settings
 	{
 		return true;

--- a/Source/FlowEditor/Private/Utils/SLevelEditorFlow.cpp
+++ b/Source/FlowEditor/Private/Utils/SLevelEditorFlow.cpp
@@ -40,7 +40,7 @@ void SLevelEditorFlow::CreateFlowWidget()
 			.AutoWidth()
 			[
 				SNew(SObjectPropertyEntryBox)
-					.AllowedClass(GetDefault<UFlowGraphSettings>()->WorldAssetClass)
+					.AllowedClass(GetDefault<UFlowGraphSettings>()->WorldAssetClass.LoadSynchronous())
 					.DisplayThumbnail(false)
 					.OnObjectChanged(this, &SLevelEditorFlow::OnFlowChanged)
 					.ObjectPath(this, &SLevelEditorFlow::GetFlowAssetPath) // needs function to automatically refresh view upon data change

--- a/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphSettings.h
@@ -85,16 +85,16 @@ class FLOWEDITOR_API UFlowGraphSettings : public UDeveloperSettings
 
 	/* Use this class to create new assets. Class picker will show up if None. */
 	UPROPERTY(EditAnywhere, config, Category = "Default UI")
-	TSubclassOf<class UFlowAsset> DefaultFlowAssetClass;
+	TSoftClassPtr<class UFlowAsset> DefaultFlowAssetClass;
 
 	/* Flow Asset class allowed to be assigned via Level Editor toolbar. */
 	UPROPERTY(EditAnywhere, config, Category = "Default UI", meta = (EditCondition = "bShowAssetToolbarAboveLevelEditor"))
-	TSubclassOf<class UFlowAsset> WorldAssetClass;
+	TSoftClassPtr<class UFlowAsset> WorldAssetClass;
 
 	/* Hide specific nodes from the Flow Palette without changing the source code.
 	 * Requires restart after making a change. */
 	UPROPERTY(EditAnywhere, config, Category = "Nodes", meta = (ConfigRestartRequired = true))
-	TArray<TSubclassOf<class UFlowNode>> NodesHiddenFromPalette;
+	TArray<TSoftClassPtr<class UFlowNode>> NodesHiddenFromPalette;
 
 	/* Configurable map of FlowAsset subclasses to the FlowAssetNodePolicy for that subclass. */
 	UPROPERTY(EditAnywhere, Config, Category = "Nodes", meta = (ConfigRestartRequired = true, AllowedClasses = "/Script/Flow.FlowAsset"))
@@ -102,7 +102,7 @@ class FLOWEDITOR_API UFlowGraphSettings : public UDeveloperSettings
 
 	/* Allows anyone to override Flow Palette category for specific nodes without modifying source code. */
 	UPROPERTY(EditAnywhere, config, Category = "Nodes")
-	TMap<TSubclassOf<class UFlowNode>, FString> OverridenNodeCategories;
+	TMap<TSoftClassPtr<class UFlowNode>, FString> OverridenNodeCategories;
 
 	/* Hide default pin names on simple nodes, reduces UI clutter. */
 	UPROPERTY(EditAnywhere, config, Category = "Nodes")
@@ -114,7 +114,7 @@ class FLOWEDITOR_API UFlowGraphSettings : public UDeveloperSettings
 	TArray<FString> NodePrefixesToRemove;
 
 	/* Display Styles for nodes, keyed by Gameplay Tag. */
-	UPROPERTY(EditAnywhere, config, Category = "Nodes", meta = (TitleProperty = "{Tag}}"))
+	UPROPERTY(EditAnywhere, config, Category = "Nodes", meta = (TitleProperty = "{Tag}"))
 	TArray<FFlowNodeDisplayStyleConfig> NodeDisplayStyles;
 
 #if WITH_EDITORONLY_DATA
@@ -131,7 +131,7 @@ class FLOWEDITOR_API UFlowGraphSettings : public UDeveloperSettings
 	TMap<EFlowNodeStyle, FLinearColor> NodeTitleColors;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Nodes")
-	TMap<TSubclassOf<UFlowNode>, FLinearColor> NodeSpecificColors;
+	TMap<TSoftClassPtr<UFlowNode>, FLinearColor> NodeSpecificColors;
 
 	UPROPERTY(EditAnywhere, config, Category = "Nodes")
 	FLinearColor ExecPinColorModifier;


### PR DESCRIPTION
I encountered a bug when dealing with hard reference (TSubclassOf) and BP class. Hard reference to BP class may cause BP compile error. See below:

# Steps to Reproduce

* Create a new plugin with a module (runtime; LoadingPhase: Default). Define a simple UStruct, `FMyDummyStruct`, in this module.
```
"Modules": [
{
	"Name": "DummyPlugin",
	"Type": "Runtime",
	"LoadingPhase": "Default"
}
]
```

```
USTRUCT(BlueprintType)
struct FMyDummyStruct
{
	GENERATED_BODY()
};
```

* Create a BP FlowNode, `FN_Test`, in the project `Content` folder. In `FN_Test`, declare a variable with type `FMyDummyStruct`. So far, everything works just fine.
<img width="865" height="304" alt="image" src="https://github.com/user-attachments/assets/5d5ef7f7-6ec0-4a60-827e-c2aad4e1b970" />

* In Project Settings, reference `FN_Test` in `OverridenNodeCategories`
<img width="865" height="415" alt="image" src="https://github.com/user-attachments/assets/91871bc3-b4e0-454d-80b2-e9f69e9081f8" />

Since `OverridenNodeCategories` is a hard reference to the BP FlowNode (`TMap<TSubclassOf<class UFlowNode>, FString>`), when I restart the project, the following errors occurs:

<img width="865" height="375" alt="image" src="https://github.com/user-attachments/assets/7a8af3bf-4b2c-431c-8299-3cbaee03b727" />

<img width="865" height="39" alt="image" src="https://github.com/user-attachments/assets/ceb48cfe-a720-4864-af1e-c440b29df6a9" />

To fix this error, I changed hard reference (`TSubclassOf`) in FlowGraphSettings to `TSoftClassPtr`.

Let me know if I was wrong.