### PR TITLE
Crash fix for Format Text node

### DIFF
--- a/Source/Flow/Private/Nodes/FlowNodeBase.cpp
+++ b/Source/Flow/Private/Nodes/FlowNodeBase.cpp
@@ -990,6 +990,11 @@ EDataValidationResult UFlowNodeBase::ValidateNode()
 
 bool UFlowNodeBase::TryAddValueToFormatNamedArguments(const FFlowNamedDataPinProperty& NamedDataPinProperty, FFormatNamedArguments& InOutArguments) const
 {
+	if (NamedDataPinProperty.Name.IsNone() || !NamedDataPinProperty.DataPinValue.IsValid())
+	{
+		return false;
+	}
+
 	const FFlowDataPinValue& DataPinValue = NamedDataPinProperty.DataPinValue.Get();
 
 	const FFlowPinTypeName PinTypeName = DataPinValue.GetPinTypeName();


### PR DESCRIPTION
Prevent Getting the value of an invalid FFlowDataPinValue property.