### PR TITLE
Fix crash when OnMapOpened delegate fires after SLevelEditorFlow destruction

### DIFF
--- a/Source/FlowEditor/Private/Utils/SLevelEditorFlow.cpp
+++ b/Source/FlowEditor/Private/Utils/SLevelEditorFlow.cpp
@@ -14,7 +14,12 @@
 void SLevelEditorFlow::Construct(const FArguments& InArgs)
 {
 	CreateFlowWidget();
-	FEditorDelegates::OnMapOpened.AddRaw(this, &SLevelEditorFlow::OnMapOpened);
+	OnMapOpenedHandle = FEditorDelegates::OnMapOpened.AddRaw(this, &SLevelEditorFlow::OnMapOpened);
+}
+
+SLevelEditorFlow::~SLevelEditorFlow()
+{
+	FEditorDelegates::OnMapOpened.Remove(OnMapOpenedHandle);
 }
 
 void SLevelEditorFlow::OnMapOpened(const FString& Filename, bool bAsTemplate)

--- a/Source/FlowEditor/Public/Utils/SLevelEditorFlow.h
+++ b/Source/FlowEditor/Public/Utils/SLevelEditorFlow.h
@@ -14,6 +14,8 @@ public:
 
 	void Construct(const FArguments& InArgs);
 
+	~SLevelEditorFlow();
+
 protected:
 	void OnMapOpened(const FString& Filename, bool bAsTemplate);
 	void CreateFlowWidget();
@@ -24,4 +26,5 @@ protected:
 	static class UFlowComponent* FindFlowComponent();
 	
 	FString FlowAssetPath;
+	FDelegateHandle OnMapOpenedHandle;
 };


### PR DESCRIPTION
The SLevelEditorFlow widget subscribes to FEditorDelegates::OnMapOpened using AddRaw, but never unsubscribes. When a map is loaded and the widget has been destroyed, the delegate fires on a stale pointer causing an access violation. Fix: Store the delegate handle and remove it in the destructor.