### PR TITLE
Fix FlowNode_LogicalOR: ExecutionLimit not working

### DIFF
--- a/Source/Flow/Private/Nodes/Route/FlowNode_LogicalOR.cpp
+++ b/Source/Flow/Private/Nodes/Route/FlowNode_LogicalOR.cpp
@@ -53,12 +53,19 @@ void UFlowNode_LogicalOR::ExecuteInput(const FName& PinName)
 	}
 }
 
-void UFlowNode_LogicalOR::Cleanup()
-{
-	ResetCounter();
-}
-
 void UFlowNode_LogicalOR::ResetCounter()
 {
 	ExecutionCount = 0;
 }
+
+#if WITH_EDITOR
+FString UFlowNode_LogicalOR::GetStatusString() const
+{
+	if (ExecutionLimit > 1)
+	{
+		return FString::Printf(TEXT("ExecutionCount: %d/%d"), ExecutionCount, ExecutionLimit);
+	}
+	
+	return Super::GetStatusString();
+}
+#endif

--- a/Source/Flow/Public/Nodes/Route/FlowNode_LogicalOR.h
+++ b/Source/Flow/Public/Nodes/Route/FlowNode_LogicalOR.h
@@ -36,7 +36,10 @@ public:
 
 protected:
 	virtual void ExecuteInput(const FName& PinName) override;
-	virtual void Cleanup() override;
 
 	void ResetCounter();
+	
+#if WITH_EDITOR
+	virtual FString GetStatusString() const override;
+#endif
 };


### PR DESCRIPTION
`FlowNode_LogicalOR` resets `ExecutionCount` to 0 every time when `Cleanup()`. Thus, `ExecutionCount` will never accumulate and never reach `ExecutionLimit`. Essentially, if we set `ExecutionLimit` to any value greater than 1, `FlowNode_LogicalOR` becomes an always-trigger node (i.e., can trigger output indefinitely).

To make `ExecutionLimit` work, I removed `Cleanup()` override in `FlowNode_LogicalOR`.

<img width="1262" height="319" alt="image" src="https://github.com/user-attachments/assets/01daae09-2353-4f4d-bc70-2f2faf167248" />

BTW, I didn't see many use cases of having `ExecutionLimit`. If users need a counter-like FLowNode, `UFlowNode_Counter` is a better choice.