### PR TITLE
CanSave check in FlowComponent

### DIFF
--- a/Source/Flow/Private/FlowComponent.cpp
+++ b/Source/Flow/Private/FlowComponent.cpp
@@ -549,7 +549,7 @@ FFlowComponentSaveData UFlowComponent::SaveInstance()
 
 bool UFlowComponent::LoadInstance(const UFlowSubsystem* FlowSubsystem)
 {
-	if (FlowSubsystem)
+	if (FlowSubsystem && CanSave())
 	{
 		if (const FFlowComponentSaveData* Record = FlowSubsystem->GetLoadedComponentRecord(GetWorld()->GetFName(), GetOwner()->GetFName()))
 		{

--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -402,7 +402,10 @@ void UFlowSubsystem::OnGameSaved(TArray<FFlowComponentSaveData>& FlowComponents,
 		{
 			if (UFlowComponent* FlowComponent = Cast<UFlowComponent>(RootInstance.Value))
 			{
-				FlowComponent->SaveRootFlow(FlowInstances);
+				if (FlowComponent->CanSave())
+				{
+					FlowComponent->SaveRootFlow(FlowInstances);
+				}				
 			}
 			else
 			{
@@ -422,7 +425,10 @@ void UFlowSubsystem::OnGameSaved(TArray<FFlowComponentSaveData>& FlowComponents,
 
 		for (const TWeakObjectPtr<UFlowComponent> RegisteredComponent : RegisteredComponents)
 		{
-			FlowComponents.Emplace(RegisteredComponent->SaveInstance());
+			if (RegisteredComponent->CanSave())
+			{
+				FlowComponents.Emplace(RegisteredComponent->SaveInstance());
+			}		
 		}
 	}
 }

--- a/Source/Flow/Public/FlowComponent.h
+++ b/Source/Flow/Public/FlowComponent.h
@@ -228,6 +228,8 @@ public:
 // SaveGame
 
 public:
+	virtual bool CanSave() const { return true; }
+	
 	UFUNCTION(BlueprintCallable, Category = "SaveGame")
 	virtual void SaveRootFlow(TArray<FFlowAssetSaveData>& SavedFlowInstances);
 


### PR DESCRIPTION
Always wanted this check, not sure why it was never added to the plugin
It provides easy extensions if you don't want to clutter your save game
1) Option to implement save optimizations like Dirty flags
2) Transient graphs and components that are never saved. 
   - environment background behavior
   - logic/fact ensures
   - level initialization
   
And while transient graphs can be handled by using empty identity, it would be much better to intentionally set them up without looking like an error