### PR TITLE
GetLoadedRecord adjust interface

### DIFF
--- a/Source/Flow/Private/FlowComponent.cpp
+++ b/Source/Flow/Private/FlowComponent.cpp
@@ -551,7 +551,7 @@ bool UFlowComponent::LoadInstance(const UFlowSubsystem* FlowSubsystem)
 {
 	if (FlowSubsystem)
 	{
-		if (const FFlowComponentSaveData* Record = FlowSubsystem->GetLoadedComponentRecord(GetWorld()->GetFName(), GetOwner()->GetFName()))
+		if (const FFlowComponentSaveData* Record = FlowSubsystem->GetLoadedComponentRecord(this))
 		{
 			FMemoryReader MemoryReader(Record->ComponentData, true);
 			FFlowArchive Ar(MemoryReader);

--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -451,7 +451,7 @@ void UFlowSubsystem::LoadRootFlow(UObject* Owner, UFlowAsset* FlowAsset, const F
 		return;
 	}
 
-	if (const FFlowAssetSaveData* AssetRecord = GetLoadedAssetRecord(SavedAssetInstanceName, FlowAsset->IsBoundToWorld()))
+	if (const FFlowAssetSaveData* AssetRecord = GetLoadedAssetRecord(Owner, FlowAsset, SavedAssetInstanceName))
 	{
 		if (UFlowAsset* LoadedInstance = CreateRootFlow(Owner, FlowAsset, bAllowMultipleInstances))
 		{
@@ -470,7 +470,7 @@ void UFlowSubsystem::LoadSubFlow(UFlowNode_SubGraph* SubGraphNode, const FString
 		return;
 	}
 
-	if (const FFlowAssetSaveData* AssetRecord = GetLoadedAssetRecord(SavedAssetInstanceName, SubGraphAsset->IsBoundToWorld()))
+	if (const FFlowAssetSaveData* AssetRecord = GetLoadedAssetRecord(SubGraphNode, SubGraphAsset, SavedAssetInstanceName))
 	{
 		UFlowAsset* LoadedInstance = CreateSubFlow(SubGraphNode, SavedAssetInstanceName);
 		if (LoadedInstance)
@@ -480,10 +480,13 @@ void UFlowSubsystem::LoadSubFlow(UFlowNode_SubGraph* SubGraphNode, const FString
 	}
 }
 
-const FFlowComponentSaveData* UFlowSubsystem::GetLoadedComponentRecord(const FName& WorldName, const FName& ActorName) const
+const FFlowComponentSaveData* UFlowSubsystem::GetLoadedComponentRecord(const UFlowComponent* Component) const
 {
 	if (LoadedSaveGame)
 	{
+		const FString WorldName = Component->GetWorld()->GetName();
+		const FString ActorName = Component->GetOwner()->GetName();
+		
 		for (const FFlowComponentSaveData& ComponentRecord : LoadedSaveGame->FlowComponents)
 		{
 			if (ComponentRecord.WorldName == WorldName && ComponentRecord.ActorInstanceName == ActorName)
@@ -496,12 +499,13 @@ const FFlowComponentSaveData* UFlowSubsystem::GetLoadedComponentRecord(const FNa
 	return nullptr;
 }
 
-const FFlowAssetSaveData* UFlowSubsystem::GetLoadedAssetRecord(const FString& SavedAssetInstanceName, const bool bAssetBoundToWorld) const
+const FFlowAssetSaveData* UFlowSubsystem::GetLoadedAssetRecord(const UObject* Owner, const UFlowAsset* Asset, const FString& SavedAssetInstanceName) const
 {
 	if (LoadedSaveGame)
 	{
 		const FName& WorldName = GetWorld()->GetFName();
-
+		const bool bAssetBoundToWorld = Asset->IsBoundToWorld();
+		
 		for (const FFlowAssetSaveData& AssetRecord : LoadedSaveGame->FlowInstances)
 		{
 			if (AssetRecord.InstanceName == SavedAssetInstanceName && (!bAssetBoundToWorld || AssetRecord.WorldName == WorldName))

--- a/Source/Flow/Public/FlowSubsystem.h
+++ b/Source/Flow/Public/FlowSubsystem.h
@@ -152,8 +152,8 @@ public:
 	UFUNCTION(BlueprintPure, Category = "FlowSubsystem")
 	UFlowSaveGame* GetLoadedSaveGame() const { return LoadedSaveGame; }
 
-	virtual const FFlowComponentSaveData* GetLoadedComponentRecord(const FName& WorldName, const FName& ActorName) const;
-	virtual const FFlowAssetSaveData* GetLoadedAssetRecord(const FString& SavedAssetInstanceName, const bool bAssetBoundToWorld) const;
+	virtual const FFlowComponentSaveData* GetLoadedComponentRecord(const UFlowComponent* Component) const;
+	virtual const FFlowAssetSaveData* GetLoadedAssetRecord(const UObject* Owner, const UFlowAsset* Asset, const FString& SavedAssetInstanceName) const;
 
 	UFUNCTION(BlueprintCallable, Category = "FlowSubsystem")
 	virtual void ClearLoadedSaveGame();


### PR DESCRIPTION
In my opinion, this accessor will be much easier to extend, because when you need to override these functions you probably changed how data stored, but not at stage where you need rework whole subsystem

For example this was enough to create derived subsystem that stores data per SubLevel/WorldPartition Cell and applies Save/Load with streaming