### PR TITLE
fixup error display in shipping, more granular logging compilation

### DIFF
--- a/Source/Flow/Private/FlowComponent.cpp
+++ b/Source/Flow/Private/FlowComponent.cpp
@@ -266,18 +266,24 @@ void UFlowComponent::OnRep_IdentityTags(const FGameplayTagContainer& PreviousTag
 
 void UFlowComponent::VerifyIdentityTags() const
 {
+#if !NO_LOGGING || UE_ENABLE_DEBUG_DRAWING
 	if (IdentityTags.IsEmpty() && GetDefault<UFlowSettings>()->bWarnAboutMissingIdentityTags)
 	{
 		FString Message = TEXT("Missing Identity Tags on the Flow Component creating Flow Asset instance! This gonna break loading SaveGame for this component!");
 		Message.Append(LINE_TERMINATOR).Append(TEXT("If you're not using SaveSystem, you can silence this warning by unchecking bWarnAboutMissingIdentityTags flag in Flow Settings."));
 		LogError(Message);
 	}
+#endif	
 }
 
 void UFlowComponent::LogError(FString Message, const EFlowOnScreenMessageType OnScreenMessageType) const
 {
+#if !NO_LOGGING || UE_ENABLE_DEBUG_DRAWING
 	Message += TEXT(" --- Flow Component in actor ") + GetOwner()->GetName();
-
+	UE_LOG(LogFlow, Error, TEXT("%s"), *Message);
+#endif
+	
+#if UE_ENABLE_DEBUG_DRAWING
 	if (OnScreenMessageType == EFlowOnScreenMessageType::Permanent)
 	{
 		if (UWorld* World = GetWorld())
@@ -302,8 +308,7 @@ void UFlowComponent::LogError(FString Message, const EFlowOnScreenMessageType On
 	{
 		GEngine->AddOnScreenDebugMessage(-1, 2.0f, FColor::Red, Message);
 	}
-
-	UE_LOG(LogFlow, Error, TEXT("%s"), *Message);
+#endif
 }
 
 void UFlowComponent::NotifyGraph(const FGameplayTag NotifyTag, const EFlowNetMode NetMode /* = EFlowNetMode::Authority*/)

--- a/Source/Flow/Private/Nodes/FlowNodeBase.cpp
+++ b/Source/Flow/Private/Nodes/FlowNodeBase.cpp
@@ -865,9 +865,21 @@ void UFlowNodeBase::UpdateNodeConfigText_Implementation()
 
 void UFlowNodeBase::LogError(FString Message, const EFlowOnScreenMessageType OnScreenMessageType) const
 {
-#if !UE_BUILD_SHIPPING
+#if !NO_LOGGING || UE_ENABLE_DEBUG_DRAWING
 	if (BuildMessage(Message))
 	{
+		// Output Log
+		UE_LOG(LogFlow, Error, TEXT("%s"), *Message);
+		
+#if WITH_EDITOR
+		if (GEditor)
+		{
+			// Message Log
+			GetFlowAsset()->GetTemplateAsset()->LogError(Message, this);
+		}
+#endif
+		
+#if UE_ENABLE_DEBUG_DRAWING
 		// OnScreen Message
 		if (OnScreenMessageType == EFlowOnScreenMessageType::Permanent)
 		{
@@ -894,16 +906,6 @@ void UFlowNodeBase::LogError(FString Message, const EFlowOnScreenMessageType OnS
 		{
 			GEngine->AddOnScreenDebugMessage(-1, 2.0f, FColor::Red, Message);
 		}
-
-		// Output Log
-		UE_LOG(LogFlow, Error, TEXT("%s"), *Message);
-
-#if WITH_EDITOR
-		if (GEditor)
-		{
-			// Message Log
-			GetFlowAsset()->GetTemplateAsset()->LogError(Message, this);
-		}
 #endif
 	}
 #endif
@@ -911,7 +913,7 @@ void UFlowNodeBase::LogError(FString Message, const EFlowOnScreenMessageType OnS
 
 void UFlowNodeBase::LogWarning(FString Message) const
 {
-#if !UE_BUILD_SHIPPING
+#if !NO_LOGGING
 	if (BuildMessage(Message))
 	{
 		// Output Log
@@ -930,7 +932,7 @@ void UFlowNodeBase::LogWarning(FString Message) const
 
 void UFlowNodeBase::LogNote(FString Message) const
 {
-#if !UE_BUILD_SHIPPING
+#if !NO_LOGGING
 	if (BuildMessage(Message))
 	{
 		// Output Log
@@ -949,7 +951,7 @@ void UFlowNodeBase::LogNote(FString Message) const
 
 void UFlowNodeBase::LogVerbose(FString Message) const
 {
-#if !UE_BUILD_SHIPPING
+#if !NO_LOGGING
 	if (BuildMessage(Message))
 	{
 		// Output Log
@@ -958,7 +960,7 @@ void UFlowNodeBase::LogVerbose(FString Message) const
 #endif
 }
 
-#if !UE_BUILD_SHIPPING
+#if !NO_LOGGING || UE_ENABLE_DEBUG_DRAWING
 bool UFlowNodeBase::BuildMessage(FString& Message) const
 {
 	const UFlowAsset* FlowAsset = GetFlowAsset();

--- a/Source/Flow/Public/Nodes/FlowNodeBase.h
+++ b/Source/Flow/Public/Nodes/FlowNodeBase.h
@@ -540,7 +540,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "FlowNode", meta = (DevelopmentOnly))
 	void LogVerbose(FString Message) const;
 
-#if !UE_BUILD_SHIPPING
+#if !NO_LOGGING || UE_ENABLE_DEBUG_DRAWING
 protected:
 	bool BuildMessage(FString& Message) const;
 #endif


### PR DESCRIPTION
UFlowComponent::LogError wrote on screen in shipping, so I wrapped it macro
But then for some reason went on overly enthusiastic check of other functions and rewrapped them in macro too