### PR TITLE
Fix invalid instance class when pasting

### DIFF
--- a/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
+++ b/Source/FlowEditor/Private/Graph/Nodes/FlowGraphNode.cpp
@@ -122,7 +122,7 @@ void UFlowGraphNode::PostEditImport()
 
 	// Reset the owning graph after an edit import
 	ResetNodeOwner();
-
+	UpdateNodeClassData();
 	if (NodeInstance)
 	{
 		InitializeInstance();


### PR DESCRIPTION
For some reason pasting nodes failed right after launching editor
Adding new node to the graph fixes the issue
After some digging, turns out NodeInstanceClass was null on import which failed some checks later(CanPasteHere iirc)
