### PR TITLE
Fix: -Wunreachable-code-loop-increment errors on Clang

### DIFF
--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -400,7 +400,7 @@ void UFlowSubsystem::OnGameSaved(TArray<FFlowComponentSaveData>& FlowComponents,
 				if (FlowComponent->CanSave())
 				{
 					FlowComponent->SaveRootFlow(FlowInstances);
-				}				
+				}
 			}
 			else
 			{
@@ -423,7 +423,7 @@ void UFlowSubsystem::OnGameSaved(TArray<FFlowComponentSaveData>& FlowComponents,
 			if (RegisteredComponent->CanSave())
 			{
 				FlowComponents.Emplace(RegisteredComponent->SaveInstance());
-			}		
+			}
 		}
 	}
 }
@@ -487,7 +487,7 @@ const FFlowComponentSaveData* UFlowSubsystem::GetLoadedComponentRecord(const UFl
 	{
 		const FString WorldName = Component->GetWorld()->GetName();
 		const FString ActorName = Component->GetOwner()->GetName();
-		
+
 		for (const FFlowComponentSaveData& ComponentRecord : LoadedSaveGame->FlowComponents)
 		{
 			if (ComponentRecord.WorldName == WorldName && ComponentRecord.ActorInstanceName == ActorName)
@@ -506,7 +506,7 @@ const FFlowAssetSaveData* UFlowSubsystem::GetLoadedAssetRecord(const UObject* Ow
 	{
 		const FName& WorldName = GetWorld()->GetFName();
 		const bool bAssetBoundToWorld = Asset->IsBoundToWorld();
-		
+
 		for (const FFlowAssetSaveData& AssetRecord : LoadedSaveGame->FlowInstances)
 		{
 			if (AssetRecord.InstanceName == SavedAssetInstanceName && (!bAssetBoundToWorld || AssetRecord.WorldName == WorldName))
@@ -742,27 +742,32 @@ void UFlowSubsystem::FindComponents(const FGameplayTagContainer& Tags, const EGa
 	{
 		for (const FGameplayTag& Tag : Tags)
 		{
-			TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
-			FindComponents(Tag, bExactMatch, ComponentsPerTag);
-			OutComponents.Append(ComponentsPerTag);
+			if (Tag.IsValid())
+			{
+				TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
+				FindComponents(Tag, bExactMatch, ComponentsPerTag);
+				OutComponents.Append(ComponentsPerTag);
+			}
 		}
 	}
 	else // EGameplayContainerMatchType::All
 	{
 		TSet<TWeakObjectPtr<UFlowComponent>> ComponentsWithAnyTag;
 
-		// Seed the candidate pool using just the first tag, then filter down to only those that have all tags.
-		if (!Tags.IsEmpty())
+		// Seed the candidate pool using just the first valid tag, then filter down to only those that have all tags.
+		for (const FGameplayTag& Tag : Tags)
 		{
-			TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
-			FindComponents(Tags.GetByIndex(0), bExactMatch, ComponentsPerTag);
-			ComponentsWithAnyTag.Append(ComponentsPerTag);
+			if (Tag.IsValid())
+			{
+				TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
+				FindComponents(Tag, bExactMatch, ComponentsPerTag);
+				break;
+			}
 		}
 
 		for (const TWeakObjectPtr<UFlowComponent>& Component : ComponentsWithAnyTag)
 		{
-			if (Component.IsValid() && 
-				(bExactMatch ? Component->IdentityTags.HasAllExact(Tags) : Component->IdentityTags.HasAll(Tags)))
+			if (Component.IsValid() && (bExactMatch ? Component->IdentityTags.HasAllExact(Tags) : Component->IdentityTags.HasAll(Tags)))
 			{
 				OutComponents.Emplace(Component);
 			}

--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -761,6 +761,7 @@ void UFlowSubsystem::FindComponents(const FGameplayTagContainer& Tags, const EGa
 			{
 				TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
 				FindComponents(Tag, bExactMatch, ComponentsPerTag);
+				ComponentsWithAnyTag.Append(ComponentsPerTag);
 				break;
 			}
 		}

--- a/Source/Flow/Private/FlowSubsystem.cpp
+++ b/Source/Flow/Private/FlowSubsystem.cpp
@@ -750,12 +750,13 @@ void UFlowSubsystem::FindComponents(const FGameplayTagContainer& Tags, const EGa
 	else // EGameplayContainerMatchType::All
 	{
 		TSet<TWeakObjectPtr<UFlowComponent>> ComponentsWithAnyTag;
-		for (const FGameplayTag& Tag : Tags)
+
+		// Seed the candidate pool using just the first tag, then filter down to only those that have all tags.
+		if (!Tags.IsEmpty())
 		{
 			TArray<TWeakObjectPtr<UFlowComponent>> ComponentsPerTag;
-			FindComponents(Tag, bExactMatch, ComponentsPerTag);
+			FindComponents(Tags.GetByIndex(0), bExactMatch, ComponentsPerTag);
 			ComponentsWithAnyTag.Append(ComponentsPerTag);
-			break;
 		}
 
 		for (const TWeakObjectPtr<UFlowComponent>& Component : ComponentsWithAnyTag)

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
@@ -266,7 +266,7 @@ void SFlowGraphEditor::BindGraphCommands()
 	CommandList->MapAction(FlowGraphCommands.EnableAllBreakpoints,
 					   FExecuteAction::CreateSP(this, &SFlowGraphEditor::EnableAllBreakpoints),
 					   FCanExecuteAction::CreateSP(this, &SFlowGraphEditor::HasAnyDisabledBreakpoints));
-	
+
 	CommandList->MapAction(FlowGraphCommands.DisableAllBreakpoints,
 	                       FExecuteAction::CreateSP(this, &SFlowGraphEditor::DisableAllBreakpoints),
 	                       FCanExecuteAction::CreateSP(this, &SFlowGraphEditor::HasAnyEnabledBreakpoints));
@@ -1585,11 +1585,15 @@ bool SFlowGraphEditor::CanFocusViewport() const
 
 void SFlowGraphEditor::JumpToNodeDefinition() const
 {
-	UFlowGraphNode* SelectedNode = *GetSelectedFlowNodes().CreateConstIterator();
-	if (SelectedNode != nullptr)
-	{
-		SelectedNode->JumpToDefinition();
-	}
+    TSet<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
+    if (SelectedNodes.Num() == 1)
+    {
+        UFlowGraphNode* SelectedNode = *SelectedNodes.CreateConstIterator();
+	    if (SelectedNode != nullptr)
+	    {
+		    SelectedNode->JumpToDefinition();
+	    }
+    }
 }
 
 bool SFlowGraphEditor::CanJumpToNodeDefinition() const

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
@@ -491,9 +491,9 @@ void SFlowGraphEditor::OnSelectedNodesChanged(const TSet<UObject*>& Nodes)
 	OnSelectionChangedEvent.ExecuteIfBound(Nodes);
 }
 
-TSet<UFlowGraphNode*> SFlowGraphEditor::GetSelectedFlowNodes() const
+TArray<UFlowGraphNode*> SFlowGraphEditor::GetSelectedFlowNodes() const
 {
-	TSet<UFlowGraphNode*> Result;
+	TArray<UFlowGraphNode*> Result;
 
 	const FGraphPanelSelectionSet SelectedNodes = GetSelectedNodes();
 	for (FGraphPanelSelectionSet::TConstIterator NodeIt(SelectedNodes); NodeIt; ++NodeIt)
@@ -1097,19 +1097,23 @@ void SFlowGraphEditor::ReconstructNode() const
 {
 	for (UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		SelectedNode->ReconstructNode();
+		if (SelectedNode->SupportsContextPins())
+		{
+			SelectedNode->ReconstructNode();
+		}
 	}
 }
 
 bool SFlowGraphEditor::CanReconstructNode() const
 {
-	TSet<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
-	if (CanEdit() && SelectedNodes.Num() == 1)
+	if (CanEdit())
 	{
-		UFlowGraphNode* SelectedNode = *SelectedNodes.CreateConstIterator();
-		if (SelectedNode != nullptr)
+		for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 		{
-			return SelectedNode->SupportsContextPins();
+			if (SelectedNode->SupportsContextPins())
+			{
+				return true;
+			}
 		}
 	}
 
@@ -1120,19 +1124,23 @@ void SFlowGraphEditor::AddInput() const
 {
 	for (UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		SelectedNode->AddUserInput();
+		if (SelectedNode->CanUserAddInput())
+		{
+			SelectedNode->AddUserInput();
+		}
 	}
 }
 
 bool SFlowGraphEditor::CanAddInput() const
 {
-	TSet<UFlowGraphNode*> SelectedFlowNodes = GetSelectedFlowNodes();
-	if (CanEdit() && SelectedFlowNodes.Num() == 1)
+	if (CanEdit())
 	{
-		UFlowGraphNode* SelectedNode = *SelectedFlowNodes.CreateConstIterator();
-		if (SelectedNode != nullptr)
+		for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 		{
-			return SelectedNode->CanUserAddInput();
+			if (SelectedNode->CanUserAddInput())
+			{
+				return true;
+			}
 		}
 	}
 
@@ -1143,19 +1151,23 @@ void SFlowGraphEditor::AddOutput() const
 {
 	for (UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		SelectedNode->AddUserOutput();
+		if (SelectedNode->CanUserAddOutput())
+		{
+			SelectedNode->AddUserOutput();
+		}
 	}
 }
 
 bool SFlowGraphEditor::CanAddOutput() const
 {
-	TSet<UFlowGraphNode*> SelectedFlowNodes = GetSelectedFlowNodes();
-	if (CanEdit() && SelectedFlowNodes.Num() == 1)
+	if (CanEdit())
 	{
-		UFlowGraphNode* SelectedNode = *SelectedFlowNodes.CreateConstIterator();
-		if (SelectedNode != nullptr)
+		for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 		{
-			return SelectedNode->CanUserAddOutput();
+			if (SelectedNode->CanUserAddOutput())
+			{
+				return true;
+			}
 		}
 	}
 
@@ -1511,7 +1523,10 @@ void SFlowGraphEditor::SetSignalMode(const EFlowSignalMode Mode) const
 
 	for (UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		SelectedNode->SetSignalMode(Mode);
+		if (SelectedNode->CanSetSignalMode(Mode))
+		{
+			SelectedNode->SetSignalMode(Mode);
+		}
 	}
 
 	FlowAsset->Modify();
@@ -1524,13 +1539,11 @@ bool SFlowGraphEditor::CanSetSignalMode(const EFlowSignalMode Mode) const
 		return false;
 	}
 
-	TSet<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
-	if (SelectedNodes.Num() == 1)
+	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
 	{
-		UFlowGraphNode* SelectedNode = *SelectedNodes.CreateConstIterator();
-		if (SelectedNode != nullptr)
+		if (SelectedNode->CanSetSignalMode(Mode))
 		{
-			return SelectedNode->CanSetSignalMode(Mode);
+			return true;
 		}
 	}
 
@@ -1550,29 +1563,29 @@ void SFlowGraphEditor::OnForcePinActivation()
 
 void SFlowGraphEditor::FocusViewport() const
 {
-	const TSet<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
-	if (SelectedNodes.IsEmpty())
+	const TArray<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
+	if (SelectedNodes.Num() == 1)
 	{
-		return;
-	}
-
-	const UFlowGraphNode* SelectedNode = *SelectedNodes.CreateConstIterator();
-	const UFlowNode* FlowNode = Cast<UFlowNode>(SelectedNode->GetFlowNodeBase());
-	if (UFlowNode* InspectedInstance = FlowNode->GetInspectedInstance())
-	{
-		if (AActor* ActorToFocus = InspectedInstance->GetActorToFocus())
+		const UFlowGraphNode* SelectedNode = SelectedNodes[0];
+		if (const UFlowNode* FlowNode = Cast<UFlowNode>(SelectedNode->GetFlowNodeBase()))
 		{
-			GEditor->SelectNone(false, false, false);
-			GEditor->SelectActor(ActorToFocus, true, true, true);
-			GEditor->NoteSelectionChange();
-
-			GEditor->MoveViewportCamerasToActor(*ActorToFocus, false);
-
-			const FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
-			const TSharedPtr<SDockTab> LevelEditorTab = LevelEditorModule.GetLevelEditorInstanceTab().Pin();
-			if (LevelEditorTab.IsValid())
+			if (UFlowNode* InspectedInstance = FlowNode->GetInspectedInstance())
 			{
-				LevelEditorTab->DrawAttention();
+				if (AActor* ActorToFocus = InspectedInstance->GetActorToFocus())
+				{
+					GEditor->SelectNone(false, false, false);
+					GEditor->SelectActor(ActorToFocus, true, true, true);
+					GEditor->NoteSelectionChange();
+
+					GEditor->MoveViewportCamerasToActor(*ActorToFocus, false);
+
+					const FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
+					const TSharedPtr<SDockTab> LevelEditorTab = LevelEditorModule.GetLevelEditorInstanceTab().Pin();
+					if (LevelEditorTab.IsValid())
+					{
+						LevelEditorTab->DrawAttention();
+					}
+				}
 			}
 		}
 	}
@@ -1585,15 +1598,12 @@ bool SFlowGraphEditor::CanFocusViewport() const
 
 void SFlowGraphEditor::JumpToNodeDefinition() const
 {
-    TSet<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
-    if (SelectedNodes.Num() == 1)
-    {
-        UFlowGraphNode* SelectedNode = *SelectedNodes.CreateConstIterator();
-	    if (SelectedNode != nullptr)
-	    {
-		    SelectedNode->JumpToDefinition();
-	    }
-    }
+	const TArray<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
+	if (SelectedNodes.Num() == 1)
+	{
+		const UFlowGraphNode* SelectedNode = SelectedNodes[0];
+		SelectedNode->JumpToDefinition();
+	}
 }
 
 bool SFlowGraphEditor::CanJumpToNodeDefinition() const

--- a/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
+++ b/Source/FlowEditor/Private/Graph/FlowGraphEditor.cpp
@@ -1103,9 +1103,11 @@ void SFlowGraphEditor::ReconstructNode() const
 
 bool SFlowGraphEditor::CanReconstructNode() const
 {
-	if (CanEdit() && GetSelectedFlowNodes().Num() == 1)
+	TSet<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
+	if (CanEdit() && SelectedNodes.Num() == 1)
 	{
-		for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
+		UFlowGraphNode* SelectedNode = *SelectedNodes.CreateConstIterator();
+		if (SelectedNode != nullptr)
 		{
 			return SelectedNode->SupportsContextPins();
 		}
@@ -1124,9 +1126,11 @@ void SFlowGraphEditor::AddInput() const
 
 bool SFlowGraphEditor::CanAddInput() const
 {
-	if (CanEdit() && GetSelectedFlowNodes().Num() == 1)
+	TSet<UFlowGraphNode*> SelectedFlowNodes = GetSelectedFlowNodes();
+	if (CanEdit() && SelectedFlowNodes.Num() == 1)
 	{
-		for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
+		UFlowGraphNode* SelectedNode = *SelectedFlowNodes.CreateConstIterator();
+		if (SelectedNode != nullptr)
 		{
 			return SelectedNode->CanUserAddInput();
 		}
@@ -1145,9 +1149,11 @@ void SFlowGraphEditor::AddOutput() const
 
 bool SFlowGraphEditor::CanAddOutput() const
 {
-	if (CanEdit() && GetSelectedFlowNodes().Num() == 1)
+	TSet<UFlowGraphNode*> SelectedFlowNodes = GetSelectedFlowNodes();
+	if (CanEdit() && SelectedFlowNodes.Num() == 1)
 	{
-		for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
+		UFlowGraphNode* SelectedNode = *SelectedFlowNodes.CreateConstIterator();
+		if (SelectedNode != nullptr)
 		{
 			return SelectedNode->CanUserAddOutput();
 		}
@@ -1518,9 +1524,14 @@ bool SFlowGraphEditor::CanSetSignalMode(const EFlowSignalMode Mode) const
 		return false;
 	}
 
-	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
+	TSet<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
+	if (SelectedNodes.Num() == 1)
 	{
-		return SelectedNode->CanSetSignalMode(Mode);
+		UFlowGraphNode* SelectedNode = *SelectedNodes.CreateConstIterator();
+		if (SelectedNode != nullptr)
+		{
+			return SelectedNode->CanSetSignalMode(Mode);
+		}
 	}
 
 	return false;
@@ -1539,30 +1550,31 @@ void SFlowGraphEditor::OnForcePinActivation()
 
 void SFlowGraphEditor::FocusViewport() const
 {
-	// Iterator used but should only contain one node
-	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
+	const TSet<UFlowGraphNode*> SelectedNodes = GetSelectedFlowNodes();
+	if (SelectedNodes.IsEmpty())
 	{
-		const UFlowNode* FlowNode = Cast<UFlowNode>(SelectedNode->GetFlowNodeBase());
-		if (UFlowNode* InspectedInstance = FlowNode->GetInspectedInstance())
+		return;
+	}
+
+	const UFlowGraphNode* SelectedNode = *SelectedNodes.CreateConstIterator();
+	const UFlowNode* FlowNode = Cast<UFlowNode>(SelectedNode->GetFlowNodeBase());
+	if (UFlowNode* InspectedInstance = FlowNode->GetInspectedInstance())
+	{
+		if (AActor* ActorToFocus = InspectedInstance->GetActorToFocus())
 		{
-			if (AActor* ActorToFocus = InspectedInstance->GetActorToFocus())
+			GEditor->SelectNone(false, false, false);
+			GEditor->SelectActor(ActorToFocus, true, true, true);
+			GEditor->NoteSelectionChange();
+
+			GEditor->MoveViewportCamerasToActor(*ActorToFocus, false);
+
+			const FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
+			const TSharedPtr<SDockTab> LevelEditorTab = LevelEditorModule.GetLevelEditorInstanceTab().Pin();
+			if (LevelEditorTab.IsValid())
 			{
-				GEditor->SelectNone(false, false, false);
-				GEditor->SelectActor(ActorToFocus, true, true, true);
-				GEditor->NoteSelectionChange();
-
-				GEditor->MoveViewportCamerasToActor(*ActorToFocus, false);
-
-				const FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
-				const TSharedPtr<SDockTab> LevelEditorTab = LevelEditorModule.GetLevelEditorInstanceTab().Pin();
-				if (LevelEditorTab.IsValid())
-				{
-					LevelEditorTab->DrawAttention();
-				}
+				LevelEditorTab->DrawAttention();
 			}
 		}
-
-		return;
 	}
 }
 
@@ -1573,11 +1585,10 @@ bool SFlowGraphEditor::CanFocusViewport() const
 
 void SFlowGraphEditor::JumpToNodeDefinition() const
 {
-	// Iterator used but should only contain one node
-	for (const UFlowGraphNode* SelectedNode : GetSelectedFlowNodes())
+	UFlowGraphNode* SelectedNode = *GetSelectedFlowNodes().CreateConstIterator();
+	if (SelectedNode != nullptr)
 	{
 		SelectedNode->JumpToDefinition();
-		return;
 	}
 }
 

--- a/Source/FlowEditor/Public/Graph/FlowGraphEditor.h
+++ b/Source/FlowEditor/Public/Graph/FlowGraphEditor.h
@@ -68,7 +68,7 @@ protected:
 public:
 	FOnSelectionChanged OnSelectionChangedEvent;
 
-	TSet<UFlowGraphNode*> GetSelectedFlowNodes() const;
+	TArray<UFlowGraphNode*> GetSelectedFlowNodes() const;
 
 protected:
 	virtual bool CanSelectAllNodes() const { return true; }


### PR DESCRIPTION
Under Clang 20.1.8 on UE 5.8.0, `-Wunreachable-code-loop-increment` is set to `-Werror`. This causes loops that unconditionally break/return to fail to compile.

This PR reworks instances of these unconditional loops in `FlowSubsystem.cpp` and `FlowGraphEditor.cpp` so that the plugin compiles under Clang, as well as adds nullptr sanity checks where applicable.