### PR TITLE
Expose node input/output pins getters, and pin type name to blueprint to enable auto testing

### DIFF
--- a/Source/Flow/Public/Nodes/FlowNode.h
+++ b/Source/Flow/Public/Nodes/FlowNode.h
@@ -148,7 +148,10 @@ protected:
 	uint8 CountNumberedOutputs() const;
 
 public:
+	UFUNCTION(BlueprintPure, Category = "FlowNode")
 	const TArray<FFlowPin>& GetInputPins() const { return InputPins; }
+
+	UFUNCTION(BlueprintPure, Category = "FlowNode")
 	const TArray<FFlowPin>& GetOutputPins() const { return OutputPins; }
 
 	UFUNCTION(BlueprintPure, Category = "FlowNode")

--- a/Source/Flow/Public/Types/FlowDataPinBlueprintLibrary.h
+++ b/Source/Flow/Public/Types/FlowDataPinBlueprintLibrary.h
@@ -42,13 +42,14 @@ public:
 	}
 
 	UFUNCTION(BlueprintPure, Category = FlowPin, Meta = (BlueprintThreadSafe, DisplayName = "Break Flow Pin"))
-	static void BreakStruct(UPARAM(DisplayName = "Flow Pin") FFlowPin Ref, FName& OutPinName, FText& OutPinFriendlyName, FString& OutPinToolTip)
+	static void BreakStruct(UPARAM(DisplayName = "Flow Pin") FFlowPin Ref, FName& OutPinName, FText& OutPinFriendlyName, FString& OutPinToolTip, FName& OutPinType)
 	{
 		OutPinName = Ref.PinName;
 #if WITH_EDITOR
 		OutPinFriendlyName = Ref.PinFriendlyName;
 		OutPinToolTip = Ref.PinToolTip;
 #endif
+		OutPinType = Ref.GetPinTypeName().Name;
 	}
 
 	/**


### PR DESCRIPTION
Hello, we have taken some early steps with automated testing, but we lack some functionality in the blueprints space. 
Changes are intended to be minimal and harmless. 
